### PR TITLE
Update to LCG 94

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,1 +1,1 @@
-source /cvmfs/sft.cern.ch/lcg/views/dev4/latest/x86_64-slc6-gcc7-opt/setup.sh
+source /cvmfs/sft.cern.ch/lcg/views/LCG_94/x86_64-slc6-gcc8-opt/setup.sh


### PR DESCRIPTION
Switched setup.sh to load LCG 94 instead.

It gets rid of the non-split branch error.