### PR TITLE
Intermediate analysis bug fixes and code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.so
+analysis/*/build/
 delphes/CaloGrid
 delphes/*.pcm
 delphes/DelphesHepMC

--- a/analysis/intermediate/Cutflow.cpp
+++ b/analysis/intermediate/Cutflow.cpp
@@ -19,7 +19,7 @@ ULong64_t Cutflow::get(const std::string& label) {
 void Cutflow::write() {
     TH1I cutflow(name.c_str(), name.c_str(), labels.size(), 0, labels.size() + 1);
     cutflow.SetDirectory(file);
-    for (int i = 1; i <= labels.size(); ++i) {
+    for (unsigned int i = 1; i <= labels.size(); ++i) {
         cutflow.GetXaxis()->SetBinLabel(i, labels[i - 1].c_str());
         cutflow.SetBinContent(i, values[i - 1].GetValue());
     }

--- a/analysis/intermediate/Cutflow.h
+++ b/analysis/intermediate/Cutflow.h
@@ -14,9 +14,9 @@ class Cutflow {
 
   public:
     Cutflow() = default;
-    Cutflow(const std::string& name /**< [in] Cutflow (and TH1) name*/,
-            TFile& file /**< [out] File to save to*/)
-        : file(&file), name(name), labels(), values() {}
+    Cutflow(const std::string& cutflowName /**< [in] Cutflow (and TH1) name*/,
+            TFile& outFile /**< [out] File to save to*/)
+        : name(cutflowName), labels(), values(), file(&outFile) {}
 
     /// Add entry to cutflow
     inline void add(const std::string& label, CountProxy&& value) {
@@ -31,8 +31,8 @@ class Cutflow {
     void write();
 
   private:
+    const std::string name;
     std::vector<std::string> labels;
     std::vector<CountProxy> values;
     TFile* file;
-    const std::string name;
 };

--- a/analysis/intermediate/inter-recon.cpp
+++ b/analysis/intermediate/inter-recon.cpp
@@ -217,7 +217,7 @@ bool sideband(const reconstructed_event& evt) {
 // Main Analysis Code
 //***************
 
-int main(int arc, char* argv[]) {
+int main(int argc, char* argv[]) {
 
     if(argc < 4){
       fprintf(stderr, "Not enough arguments provided! Need input filepath, output dir, and output filename.\n");
@@ -225,7 +225,6 @@ int main(int arc, char* argv[]) {
     }
 
     std::ios::sync_with_stdio(false);
-    using vec_string = std::vector<std::string>;
 
     const std::string file_path = argv[1];
     const std::string output_dir = argv[2];

--- a/analysis/intermediate/utils.h
+++ b/analysis/intermediate/utils.h
@@ -99,6 +99,20 @@ inline JetPair make_pair(OxJet& jet1, OxJet& jet2) {
     return JetPair(m_1, m_2, j_1, j_2);
 }
 
+// Function to check angular distance between
+// large R jet and small R jet
+double deltaR(OxJet& jet1, OxJet& jet2) {
+    using namespace std;
+
+    double deta = jet1.p4.Eta() - jet2.p4.Eta();
+    double dphi = fabs(jet1.p4.Phi() - jet2.p4.Phi());
+    while(dphi > TMath::TwoPi()) dphi -= TMath::TwoPi();
+    if(dphi > TMath::Pi()) dphi = TMath::TwoPi() - dphi;
+
+    return sqrt(deta*deta + dphi*dphi);
+}
+
+// Reconstructed event in the intermediate regime
 // Reconstructed event information
 struct reconstructed_event {
     bool valid;           ///< Is event valid

--- a/analysis/intermediate/utils.h
+++ b/analysis/intermediate/utils.h
@@ -3,6 +3,9 @@
 //
 //
 
+#ifndef INTERMEDIATE_ANALYSIS_UTILS_H
+#define INTERMEDIATE_ANALYSIS_UTILS_H
+
 #pragma once
 #include <array>
 #include <cmath>
@@ -101,7 +104,7 @@ inline JetPair make_pair(OxJet& jet1, OxJet& jet2) {
 
 // Function to check angular distance between
 // large R jet and small R jet
-double deltaR(OxJet& jet1, OxJet& jet2) {
+inline double deltaR(OxJet& jet1, OxJet& jet2) {
     using namespace std;
 
     double deta = jet1.p4.Eta() - jet2.p4.Eta();
@@ -323,3 +326,5 @@ void write_tree(ROOT::RDF::RInterface<Proxied>& result, const char* treename,
     signal_tree->Write("", TObject::kOverwrite);
     fmt::print("\n");
 }
+
+#endif


### PR DESCRIPTION
This fixes several bugs in the intermediate analysis:
- The deltaR function now correctly accounts for phi wrap-around.
- The deltaR function now actually returns the result of its calculation.
- Small-R b-jets that are close to a large-R b-jet are now properly kept track of.

A few general improvements have also been made to the code, and all compiler warnings have been resolved:
- Some unnecessarily complicated code blocks have been simplified substantially.
- The deltaR function has been moved the utils header, which is a more sensible location.
- An error message will now be given if you provide invalid command-line arguments.
- Some unused variables have been removed.
- Constructor member initialization for the Cutflow object is now done in the correct order.