### PR TITLE
Further intermediate analysis bugfixes

### DIFF
--- a/analysis/intermediate/utils.h
+++ b/analysis/intermediate/utils.h
@@ -49,8 +49,8 @@ class OxJet {
     float btag;        ///< B-tagging score
     bool tagged;       ///< Is jet B-tagged?
 
-    OxJet() : p4(), tagged(false) {}
-    OxJet(double M, double pT, double eta, long double phi, bool tagged) : p4(), tagged(tagged) {
+    OxJet() : p4(), btag(0), tagged(false) {}
+    OxJet(double M, double pT, double eta, long double phi, bool tagged) : p4(), btag(0), tagged(tagged) {
         p4.SetPtEtaPhiM(pT, eta, phi, M);
     }
 };
@@ -77,6 +77,8 @@ class JetPair {
     JetPair() : mass_1(0), mass_2(0), jet_1(), jet_2() {}
     JetPair(double M_1, double M_2, OxJet first_jet, OxJet second_jet)
         : mass_1(M_1), mass_2(M_2), jet_1(first_jet), jet_2(second_jet) {}
+
+    TLorentzVector p4(){return jet_1.p4 + jet_2.p4;}
 };
 
 // Make jet function


### PR DESCRIPTION
This fixes two more issues I found with the intermediate analysis code while trying to make sense of the kinematic distributions I was getting.

 - The mass of the resolved Higgs is now calculated correctly instead of just scalar-summing the two individual jet masses.
 - The two jets selected to form the resolved Higgs are now correctly two different jets rather than two copies of the same jet.

I've also added a p4() function to the JetPair class for convenient access of Higgs candidate kinematics.