### PR TITLE
Higgs Candidate Bug Fix(es)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 *.so
 compile_commands.json
 analysis/*/build/
+analysis/*/classes
+analysis/outputs/*
+!analysis/output/haddme.sh
+!analysis/output/haddme_ktkl.py
 delphes/CaloGrid
 delphes/*.pcm
 delphes/DelphesHepMC

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ compile_commands.json
 analysis/*/build/
 analysis/*/classes
 analysis/outputs/*
-!analysis/output/haddme.sh
-!analysis/output/haddme_ktkl.py
+!analysis/outputs/haddme.sh
+!analysis/outputs/haddme_ktkl.py
 delphes/CaloGrid
 delphes/*.pcm
 delphes/DelphesHepMC

--- a/analysis/intermediate/utils.h
+++ b/analysis/intermediate/utils.h
@@ -60,7 +60,9 @@ struct higgs {
 struct dihiggs {
   higgs higgs1;
   higgs higgs2;
+  bool isValid;
 
+  dihiggs() : isValid(false){}
 };
 
 // Make jet from Oxjet function


### PR DESCRIPTION
This fixes 2 problems with the definition of the Higgs candidates for the intermediate and boosted analyses:
- Small-R jets and track jets were swapped in the Higgs candidate construction.
- Jets could be paired with themselves for the resolved candidate in the intermediate analysis.

Additionally, a validity property has been added to the `dihiggs` struct. This is always initialized to `false` and is only set to `true` if two valid Higgs candidates are actually constructed. It's also included in the event validity definition. For example, this will remove resolved events for which no pairing satisfied the angular requirements (they were previously included in the output ntuple as spurious default-initialized Higgses).

I've also added a few more items to `.gitignore` for convenience.