### PR TITLE
k-factors, upped b-tag, multibin, 0.3% syst

### DIFF
--- a/analysis/plotting/auto_chiSq_to_1Dlimit.py
+++ b/analysis/plotting/auto_chiSq_to_1Dlimit.py
@@ -53,72 +53,33 @@ myDarkBlue       = TColor.GetColor('#08306b')
 myBlack          = TColor.GetColor('#000105')
 
 # cut_sel colour dictionary
-d_cut_sel_colour = {'resolved-finalSR' : myRedPink3,
-                    'intermediate-finalSR' : myRedPink6,
-                    'boosted-finalSR' : myRedPink9,
-                    'resolved-finalSR_AND_intermediate-finalSR_combined' : myRed,
-                    'boosted-finalSR_AND_resolved-finalSR_AND_intermediate-finalSR_combined_combined' : myPink,
-
-                    'resolved-finalSRNNQCD' : myVeryLightBlue,
-                    'intermediate-finalSRNNQCD' : myLightBlue,
-                    'boosted-finalSRNNQCD' : myMediumBlue,
-                    'resolved-finalSRNNQCD_AND_intermediate-finalSRNNQCD_combined' : myDarkBlue,
-                    'boosted-finalSRNNQCD_AND_resolved-finalSRNNQCD_AND_intermediate-finalSRNNQCD_combined_combined' : myBlack,
-
-                    'resolved-finalSRNNQCDTop' : myMediumOrange,
-                    'intermediate-finalSRNNQCDTop' : myDarkOrange,
-                    'boosted-finalSRNNQCDTop' : myDarkerOrange,
-                    'resolved-finalSRNNQCDTop_AND_intermediate-finalSRNNQCDTop_combined' : myBrown,
-                    'boosted-finalSRNNQCDTop_AND_resolved-finalSRNNQCDTop_AND_intermediate-finalSRNNQCDTop_combined_combined' : myYellow,
+d_cut_sel_colour = {
+                    'SR_res_multibin_combined' : myPink,
+                    'SR_int_multibin_combined' : myMediumPurple,
+                    'SR_bst_multibin_combined' : myDarkPurple,
+                    'SR_all_multibin_combined' : myMediumBlue,
                     
-                    #'resolved-finalSRNNlow_AND_resolved-finalSRNN_combined': myLightPurple,
-                    #'intermediate-finalSRNNlow_AND_intermediate-finalSRNN_combined': myMediumPurple,
-                    #'boosted-finalSRNNlow_AND_boosted-finalSRNN_combined': myDarkPurple, 
-
-                    'resolved-finalSRNN' : myDarkPurple,
-                    'intermediate-finalSRNN' : myMediumPurple,
-                    'boosted-finalSRNN' : myLightPurple,
-                    #'resolved-finalSRNN_AND_intermediate-finalSRNN_combined' : myVeryDarkPurple,
-                    'resolved-finalSRNNlam10_intermediate-finalSRNNlam10_boosted-finalSRNNlam10_combined': myMediumBlue,
-                    'resolved-finalSRNN_intermediate-finalSRNN_boosted-finalSRNN_combined': myMediumBlue,
-                    'resolved-finalSR_intermediate-finalSR_boosted-finalSR_combined' : myMediumBlue,
-                    #boosted-finalSRNN_AND_resolved-finalSRNN_AND_intermediate-finalSRNN_combined_combined' : myGrey,
-
-                    'resolved-finalSRNNlow_AND_resolved-finalSRNN_combined' : myBrightGreen,
-                    'intermediate-finalSRNNlow_AND_intermediate-finalSRNN_combined' : myMediumGreen,
-                    'boosted-finalSRNNlow_AND_boosted-finalSRNN_combined' : myDarkGreen,
-                    'resolved-finalSRNNlow_AND_resolved-finalSRNN_combined_AND_intermediate-finalSRNNlow_AND_intermediate-finalSRNN_combined_combined' : myMediumBlue,
-                    'boosted-finalSRNNlow_AND_boosted-finalSRNN_combined_AND_resolved-finalSRNNlow_AND_resolved-finalSRNN_combined_AND_intermediate-finalSRNNlow_AND_intermediate-finalSRNN_combined_combined_combined' : myRed,
-
-
-                    'resolved-finalSRNNlam10low_AND_resolved-finalSRNNlam10_combined' : myBrightGreen,
-                    'intermediate-finalSRNNlam10low_AND_intermediate-finalSRNNlam10_combined' : myMediumGreen,
-                    'boosted-finalSRNNlam10low_AND_boosted-finalSRNNlam10_combined' : myDarkGreen,
-                    'resolved-finalSRNNlam10low_AND_resolved-finalSRNNlam10_combined_AND_intermediate-finalSRNNlam10low_AND_intermediate-finalSRNNlam10_combined_combined' : myMediumBlue,
-                    'boosted-finalSRNNlam10low_AND_boosted-finalSRNNlam10_combined_AND_resolved-finalSRNNlam10low_AND_resolved-finalSRNNlam10_combined_AND_intermediate-finalSRNNlam10low_AND_intermediate-finalSRNNlam10_combined_combined_combined' : myRed,
-
-                    'resolved-finalSRN$lam' : myDarkerOrange,
-                    'intermediate-finalSRNNlam' : myDarkOrange,
-                    'boosted-finalSRNNlam' : myMediumOrange,
+                    'SRNN_res_multibin_lam1_combined' : myPink,
+                    'SRNN_int_multibin_lam1_combined' : myMediumPurple,
+                    'SRNN_bst_multibin_lam1_combined' : myDarkPurple,
+                    'SRNN_all_multibin_lam1_combined' : myMediumBlue,
                     
-                    'resolved-finalSRNNlamm5' : myDarkerOrange,
-                    'intermediate-finalSRNNlamm5' : myDarkOrange,
-                    'boosted-finalSRNNlamm5' : myMediumOrange,
+                    'SRNN_res_multibin_lam5_combined' : myPink,
+                    'SRNN_int_multibin_lam5_combined' : myMediumPurple,
+                    'SRNN_bst_multibin_lam5_combined' : myDarkPurple,
+                    'SRNN_all_multibin_lam5_combined' : myMediumBlue,
                     
-                    'resolved-finalSRNNlam10' : myDarkerOrange,
-                    'intermediate-finalSRNNlam10' : myDarkOrange,
-                    'boosted-finalSRNNlam10' : myMediumOrange,
-                    
-                    'resolved-finalSRNNlam10' : myDarkPurple,
-                    'intermediate-finalSRNNlam10' : myMediumPurple,
-                    'boosted-finalSRNNlam10' : myLightPurple,
+                    'SRNN_res_multibin_lam10_combined' : myPink,
+                    'SRNN_int_multibin_lam10_combined' : myMediumPurple,
+                    'SRNN_bst_multibin_lam10_combined' : myDarkPurple,
+                    'SRNN_all_multibin_lam10_combined' : myMediumBlue,
                    }
 
 # Labels
 SQRTS_LUMI = '#sqrt{s} = 14 TeV, 3000 fb^{#minus1}'
 
 # Switch to true to zoom in on x-axis 
-zoom_in = False
+zoom_in = True
 
 #____________________________________________________________________________
 def main():
@@ -134,20 +95,28 @@ def main():
   legend_outside_plot = False
  
   # Cut selections
-  # all step by step improvements 
-  ###
-  #l_cut_sels = ['resolved-finalSR','resolved-finalSRNNQCD', 'resolved-finalSRNNQCDTop','resolved-finalSRNN', 'resolved-finalSRNNlow_AND_resolved-finalSRNN_combined']
-  #l_cut_sels = ['intermediate-finalSR','intermediate-finalSRNNQCD', 'intermediate-finalSRNNQCDTop','intermediate-finalSRNN', 'intermediate-finalSRNNlow_AND_intermediate-finalSRNN_combined']
-  #l_cut_sels = ['boosted-finalSR','boosted-finalSRNNQCD', 'boosted-finalSRNNQCDTop','boosted-finalSRNN', 'boosted-finalSRNNlow_AND_boosted-finalSRNN_combined']
-
-  # combos
   d_SRsets = {}
-  d_SRsets['SRbase']    = ['resolved-finalSR', 'intermediate-finalSR', 'boosted-finalSR', 'resolved-finalSR_intermediate-finalSR_boosted-finalSR_combined']
-  d_SRsets['SRNN']      = ['resolved-finalSRNN', 'intermediate-finalSRNN', 'boosted-finalSRNN', 'resolved-finalSRNN_intermediate-finalSRNN_boosted-finalSRNN_combined']
-  d_SRsets['SRNNlam10'] = ['resolved-finalSRNNlam10', 'intermediate-finalSRNNlam10', 'boosted-finalSRNNlam10', 'resolved-finalSRNNlam10_intermediate-finalSRNNlam10_boosted-finalSRNNlam10_combined']
- 
-  l_zCols = ['chiSqSyst1pc', 'chiSqSyst0p5pc', 'chiSq']
+  d_SRsets['baseline']   = ['SR_res_multibin_combined', 
+                            'SR_int_multibin_combined', 
+                            'SR_bst_multibin_combined', 
+                            'SR_all_multibin_combined']
+
+  d_SRsets['SRNN_lam1']  = ['SRNN_res_multibin_lam1_combined', 
+                            'SRNN_int_multibin_lam1_combined', 
+                            'SRNN_bst_multibin_lam1_combined', 
+                            'SRNN_all_multibin_lam1_combined']
   
+  d_SRsets['SRNN_lam5']  = ['SRNN_res_multibin_lam5_combined', 
+                            'SRNN_int_multibin_lam5_combined', 
+                            'SRNN_bst_multibin_lam5_combined', 
+                            'SRNN_all_multibin_lam5_combined']
+  
+  d_SRsets['SRNN_lam10'] = ['SRNN_res_multibin_lam10_combined', 
+                            'SRNN_int_multibin_lam10_combined', 
+                            'SRNN_bst_multibin_lam10_combined', 
+                            'SRNN_all_multibin_lam10_combined']
+  
+  l_zCols = ['chiSqSyst0p3pc', 'chiSq']
   IsLogY = False
 
   d_axis_tlatex = {
@@ -159,10 +128,12 @@ def main():
     'SoverSqrtB'        : 'S / #sqrt{B}',
     'SoverSqrtBSyst1pc' : 'S / #sqrt{B + (1%B)^{2}}',
     'chiSq'             : '#chi^{2}',
+    'chiSqSyst0p3pc'    : '#chi^{2}',
     'chiSqSyst1pc'      : '#chi^{2}',
     'sum_chiSq'         : '#chi^{2}',
     'sum_chiSqSyst1pc'  : '#chi^{2}',
     'sum_chiSqSyst0p5pc' : '#chi^{2}',
+    'sum_chiSqSyst0p3pc' : '#chi^{2}',
   }
 
   d_in_data = {}
@@ -176,7 +147,7 @@ def main():
       if do_ktop:
         out_file = 'figs/limit1d_TopYuk_vary_SlfCoup_1p0_{0}_{1}'.format(cut_sel_out_name, zCol)
       else: 
-        out_file = 'figs/limit1d_TopYuk_1p0_SlfCoup_vary_{0}_{1}'.format(cut_sel_out_name, zCol)
+        out_file = 'figs/limit1d_TopYuk_1p0_SlfCoup_vary_{0}_{1}'.format(l_cut_sels[-1], zCol)
       
       for cut_sel in l_cut_sels:
         print(cut_sel)
@@ -213,7 +184,9 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
   gpLeft = 0.11
   customise_gPad(top=0.08, bot=0.20, left=gpLeft, right=gpRight)
   
-  # construct legend
+  #------------------------------------------------------
+  # Construct legend
+  #------------------------------------------------------
   #xl1, yl1 = 0.45, 0.68
   #xl2, yl2 = xl1+0.25, yl1+0.20
   extra_space = (0.05*len(l_cut_sels))+(0.03*str(l_cut_sels).count("combined"))
@@ -226,12 +199,12 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
       xl1, yl1 = 0.45, 0.5
   elif extra_space > 0.25:
     if zoom_in: 
-      xl1, yl1 = 0.45, 0.54
+      xl1, yl1 = 0.43, 0.38
     else:
-      xl1, yl1 = 0.45, 0.6
+      xl1, yl1 = 0.43, 0.6
   elif extra_space > 0.:
     if zoom_in: 
-      xl1, yl1 = 0.45, 0.54
+      xl1, yl1 = 0.35, 0.54
     else:
       xl1, yl1 = 0.48, 0.50
 
@@ -254,6 +227,24 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
   leg.SetFillStyle(0) # transparent
   leg.SetTextSize(0.045)
   leg.SetTextFont(132)
+  
+  # ------------------------------------------------------ 
+  # ATLAS PHYS-PUB-2018-053 constraints
+  # ------------------------------------------------------ 
+  # 0% systematics limits
+  if 'chiSq' in zCol and 'pc' not in zCol:
+    HLLHC_lam1 = -0.5
+    HLLHC_lam2 = 5.0
+  # Use 0.3% systematics limits
+  else:
+    HLLHC_lam1 = -2.5
+    HLLHC_lam2 = 6.5
+  lim_ATL_HLLHC_left  = TBox (-8.2, 0., HLLHC_lam1, 5.)
+  lim_ATL_HLLHC_right = TBox (HLLHC_lam2, 0., 13.5, 5.)
+  lim_ATL_HLLHC_left.SetFillColorAlpha(kGray+1,  0.2)
+  lim_ATL_HLLHC_right.SetFillColorAlpha(kGray+1, 0.2)
+  
+  leg.AddEntry(lim_ATL_HLLHC_left, 'ATLAS 3 ab^{#minus1}', 'f')
   
   #------------------------------------------------------
   # Get and organise data
@@ -278,8 +269,8 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
 
     if 'combined' in cut_sel:
       print(zCol)
-      zCol = 'sum_' + str(zCol)
-    in_z = [float(i) for i in d_csv[zCol] ]
+      zCol_key = 'sum_' + str(zCol)
+    in_z = [float(i) for i in d_csv[zCol_key] ]
 
     l_SlfCoup_or_TopYuk = []
     l_chiSq   = []
@@ -304,6 +295,10 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
       tg.SetPoint(i, x, y)
     d_tgraphs[cut_sel] = tg
   
+  #------------------------------------------------------
+  # Annotating text for plots
+  #------------------------------------------------------
+  
     if 'SRNN' in cut_sel:
       analysis = 'DNN'
     else:
@@ -313,12 +308,14 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
       cut_txt = 'Combined '
     elif 'resolved' in cut_sel and 'intermediate' in cut_sel:
       cut_txt = 'Res + Int '
-    elif 'resolved' in cut_sel:
+    elif 'res' in cut_sel:
       cut_txt = 'Resolved '
-    elif 'intermediate' in cut_sel:
+    elif 'int' in cut_sel:
       cut_txt = 'Intermediate '
-    elif 'boosted' in cut_sel:
+    elif 'bst' in cut_sel or 'boosted' in cut_sel:
       cut_txt = 'Boosted '
+    elif 'all' in cut_sel:
+      cut_txt = 'Combined '
     else:
       cut_name = cut_sel.split('-')
       cut_txt = cut_name[0].capitalize()# + ' ' + cut_name[1] 
@@ -337,8 +334,9 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
   
     if 'NN' in cut_sel: 
       if 'lam10' in cut_sel:
-        #cut_txt += ' #lambda_{10} '
         myText(0.08, 0.07, 'DNN trained on #kappa(#lambda_{hhh}) = 10', 0.035, kGray+2, 0, True)
+      elif 'lam5' in cut_sel:
+        myText(0.08, 0.07, 'DNN trained on #kappa(#lambda_{hhh}) = 5', 0.035, kGray+2, 0, True)
       else:
         myText(0.08, 0.07, 'DNN trained on #kappa(#lambda_{hhh}) = 1', 0.035, kGray+2, 0, True)
 
@@ -351,7 +349,7 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
       tg.Draw('PLA')
     else:
       tg.Draw('PL same')
-    
+   
     count+=1
     # ------------------------------------------------------ 
     # Attempt to search x where chiSq = 1, 3.84 points
@@ -405,8 +403,8 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
 
   if 'chiSqSyst1pc' in zCol:
     syst_txt = '1% systematics'
-  elif 'chiSqSyst0p5pc' in zCol:
-    syst_txt = '0.5% systematics'
+  elif 'chiSqSyst0p3pc' in zCol:
+    syst_txt = '0.3% systematics'
   elif 'chiSq' in zCol and 'pc' not in zCol:
     syst_txt = '0% systematics'
   else:
@@ -435,8 +433,8 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
         mymax = 1.5
     else:
       if zoom_in:
-        mymin = -10
-        mymax = 10
+        mymin = -8
+        mymax = 13
       else:
         mymin = -20
         mymax = 20
@@ -474,6 +472,11 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
   #customise_axes(d_tgraphs['resolved-finalSR'], xtitle, ytitle, 2.8, IsLogY)
   customise_axes(d_tgraphs[l_cut_sels[0]], xtitle, ytitle, 2.8, IsLogY, doktop = do_ktop)#, 2.8)
   
+
+  lim_ATL_HLLHC_left.Draw('same')
+  lim_ATL_HLLHC_right.Draw('same')
+ 
+
   #==========================================================
   # save everything
   can.cd()
@@ -533,7 +536,7 @@ def customise_axes(hist, xtitle, ytitle, scaleFactor=1.1, IsLogY=False, enlargeY
       xax.SetRangeUser(0.5,1.5) 
   else:
     if zoom_in:
-      xax.SetRangeUser(-10,10) 
+      xax.SetRangeUser(-8,13) 
     else:
       xax.SetRangeUser(-20,20) 
       #xax.SetRangeUser(-15,15) 

--- a/analysis/plotting/chiSq_2dlambda_discrPowerMatrix.py
+++ b/analysis/plotting/chiSq_2dlambda_discrPowerMatrix.py
@@ -134,9 +134,11 @@ def heatmap(AUC, title, xlabel, ylabel, xticklabels, yticklabels, zlabel, my_fil
       fig.text(0.17, 0.83, r'$hh \to 4b~\textrm{Neural network analysis}$', color='Black', size=25)
     else:
       fig.text(0.17, 0.83, r'$hh \to 4b~\textrm{Baseline analysis}$', color='Black', size=25)
-    fig.text(0.17, 0.765, r'$1\%~\textrm{systematics}$', color='Black', size=25)
-    
-    if 'resolved' in my_file:
+    fig.text(0.17, 0.765, r'$0.3\%~\textrm{systematics}$', color='Black', size=25)
+   
+    if 'combined' in my_file:
+      fig.text(0.17, 0.71, r'$\textrm{Combined categories}$', color='Black', size=25) 
+    elif 'resolved' in my_file:
       fig.text(0.17, 0.71, r'$\textrm{Resolved~category}$', color='Black', size=25)
     elif 'intermediate' in my_file:
       fig.text(0.17, 0.71, r'$\textrm{Intermediate~category}$', color='Black', size=25)
@@ -146,6 +148,8 @@ def heatmap(AUC, title, xlabel, ylabel, xticklabels, yticklabels, zlabel, my_fil
     if 'SRNN' in my_file:
       if 'lam10' in my_file:
         fig.text(0.17, 0.65, r'$\textrm{DNN trained on}~\kappa(\lambda_{hhh}) = 10$', color='Black', size=25)
+      elif 'lam5' in my_file:
+        fig.text(0.17, 0.65, r'$\textrm{DNN trained on}~\kappa(\lambda_{hhh}) = 5$', color='Black', size=25)
       else:
         fig.text(0.17, 0.65, r'$\textrm{DNN trained on}~\kappa(\lambda_{hhh}) = 1$', color='Black', size=25)
     
@@ -171,23 +175,24 @@ def main():
   # Data files to plot
   #----------------------------------------------
   l_files = [
-    'CHISQ_2Dlambda_loose_preselection_resolved-finalSR.csv',
-    'CHISQ_2Dlambda_loose_preselection_intermediate-finalSR.csv',
-    'CHISQ_2Dlambda_loose_preselection_boosted-finalSR.csv',
-    'CHISQ_2Dlambda_loose_preselection_resolved-finalSRNN.csv',
-    'CHISQ_2Dlambda_loose_preselection_intermediate-finalSRNN.csv',
-    'CHISQ_2Dlambda_loose_preselection_boosted-finalSRNN.csv',
-    'CHISQ_2Dlambda_loose_preselection_resolved-finalSRNNlam10.csv',
-    'CHISQ_2Dlambda_loose_preselection_intermediate-finalSRNNlam10.csv',
-    'CHISQ_2Dlambda_loose_preselection_boosted-finalSRNNlam10.csv',
+    'CHISQ_2Dlambda_loose_preselection_SR_res_multibin_combined_chiSq_ij_Sys0p3pc.csv',
+    'CHISQ_2Dlambda_loose_preselection_SR_int_multibin_combined_chiSq_ij_Sys0p3pc.csv',
+    'CHISQ_2Dlambda_loose_preselection_SR_bst_multibin_combined_chiSq_ij_Sys0p3pc.csv',
+    'CHISQ_2Dlambda_loose_preselection_SR_all_multibin_combined_chiSq_ij_Sys0p3pc.csv',
+    'CHISQ_2Dlambda_loose_preselection_SRNN_res_multibin_lam1_combined_chiSq_ij_Sys0p3pc.csv',
+    'CHISQ_2Dlambda_loose_preselection_SRNN_int_multibin_lam1_combined_chiSq_ij_Sys0p3pc.csv',
+    'CHISQ_2Dlambda_loose_preselection_SRNN_bst_multibin_lam1_combined_chiSq_ij_Sys0p3pc.csv',
+    'CHISQ_2Dlambda_loose_preselection_SRNN_all_multibin_lam1_combined_chiSq_ij_Sys0p3pc.csv',
+    'CHISQ_2Dlambda_loose_preselection_SRNN_res_multibin_lam5_combined_chiSq_ij_Sys0p3pc.csv',
+    'CHISQ_2Dlambda_loose_preselection_SRNN_int_multibin_lam5_combined_chiSq_ij_Sys0p3pc.csv',
+    'CHISQ_2Dlambda_loose_preselection_SRNN_bst_multibin_lam5_combined_chiSq_ij_Sys0p3pc.csv',
+    'CHISQ_2Dlambda_loose_preselection_SRNN_all_multibin_lam5_combined_chiSq_ij_Sys0p3pc.csv',
   ]
 
   for my_file in l_files:
 
-    bkg_correlation_matrix = []
-    bkg_correlation = []
-    sig_correlation_matrix = []
-    sig_correlation = []    
+    correlation_matrix = []
+    correlation = []
     
     l_varX = []
     l_varY = []
@@ -209,16 +214,12 @@ def main():
         
         # Fill each set of lambda values in a new list
         if not float( row[0] ) == previous_lambda:
-          bkg_correlation_matrix.append(bkg_correlation)
-          bkg_correlation = []
-          sig_correlation_matrix.append(sig_correlation)
-          sig_correlation = []
+          correlation_matrix.append(correlation)
+          correlation = []
         if float(row[0]) > float(row[1]):
-          bkg_correlation.append(-1.)
-          sig_correlation.append(-1.)
+          correlation.append(-1.)
         else:
-          bkg_correlation.append(float(row[2]))
-          sig_correlation.append(float(row[3]))
+          correlation.append(float(row[3]))
         if row[0] not in l_varX:
           l_varX.append(float(row[0]))
         if row[1] not in l_varY:
@@ -226,14 +227,12 @@ def main():
 
         previous_lambda = float(row[0])
       # add the last correlations to the matrix
-      bkg_correlation_matrix.append(bkg_correlation)
-      sig_correlation_matrix.append(sig_correlation)
+      correlation_matrix.append(correlation)
         
     #----------------------------------------------
     # Convert nested lists into numpy array
     #----------------------------------------------
-    data = np.array(bkg_correlation_matrix)
-    #data = np.array(sig_correlation_matrix)
+    data = np.array(correlation_matrix)
     #print(data)
     
     #----------------------------------------------

--- a/analysis/plotting/chiSq_to_1Dlimit.py
+++ b/analysis/plotting/chiSq_to_1Dlimit.py
@@ -60,8 +60,7 @@ def main():
                 'boosted-finalSR',
                 'resolved-finalSR_intermediate-finalSR_boosted-finalSR_combined'] 
  
-  l_zCols = ['chiSq', 'chiSqSyst1pc']
-  l_zCols = ['chiSqSyst1pc']
+  l_zCols = ['chiSq', 'chiSqSyst0p3pc']
   IsLogY = False
   #l_zCols = ['xsec','acceptance']
   #IsLogY = True
@@ -78,18 +77,18 @@ def main():
   #  'xsec'              : r'xsec [pb]',
   #}
   d_axis_tlatex = {
-    'acceptance'        : 'A #times \epsilon (S / #sigma #times L) [%]',
-    'xsec'              : 'xsec [pb]',
-    'N_sig'             : 'Signal yield',
-    'N_sig_raw'         : 'Raw signal yield',
-    'SoverB'            : 'S / B',
-    'SoverSqrtB'        : 'S / #sqrt{B}',
-    'SoverSqrtBSyst1pc' : 'S / #sqrt{B + (1%B)^{2}}',
-    'SoverSqrtBSyst5pc' : 'S / #sqrt{B + (5%B)^{2}}',
-    'chiSq'             : '#chi^{2} = (S #minus S_{SM})^{2} / B',
-    'chiSqSyst1pc'      : '#chi^{2}_{syst} = (S #minus S_{SM})^{2} / (B + (1%B)^{2})',
-    'sum_chiSqSyst1pc'      : '#chi^{2}_{syst} = (S #minus S_{SM})^{2} / (B + (1%B)^{2})',
-    'chiSqSyst5pc'      : '#chi^{2}_{syst} = (S #minus S_{SM})^{2} / (B + (5%B)^{2})',
+    'acceptance'          : 'A #times \epsilon (S / #sigma #times L) [%]',
+    'xsec'                : 'xsec [pb]',
+    'N_sig'               : 'Signal yield',
+    'N_sig_raw'           : 'Raw signal yield',
+    'SoverB'              : 'S / B',
+    'SoverSqrtB'          : 'S / #sqrt{B}',
+    'SoverSqrtBSyst1pc'   : 'S / #sqrt{B + (1%B)^{2}}',
+    'SoverSqrtBSyst0p3pc' : 'S / #sqrt{B + (0.3%B)^{2}}',
+    'chiSq'               : '#chi^{2} = (S #minus S_{SM})^{2} / B',
+    'chiSqSyst0p3pc'      : '#chi^{2}_{syst} = (S #minus S_{SM})^{2} / (B + (0.3%B)^{2})',
+    'chiSqSyst1pc'        : '#chi^{2}_{syst} = (S #minus S_{SM})^{2} / (B + (1%B)^{2})',
+    'chiSqSyst5pc'        : '#chi^{2}_{syst} = (S #minus S_{SM})^{2} / (B + (5%B)^{2})',
   }
 
   d_in_data = {}

--- a/analysis/plotting/chiSq_to_contour.py
+++ b/analysis/plotting/chiSq_to_contour.py
@@ -45,9 +45,6 @@ def main():
   # ------------------------------------------------------
   
   # resolved + intermediate + boosted
-  l_cut_sels = ['boosted-finalSR_AND_resolved-finalSR_AND_intermediate-finalSR_combined_combined']
-  l_cut_sels = ['boosted-finalSRNNlow_AND_boosted-finalSRNN_combined_AND_resolved-finalSRNNlow_AND_resolved-finalSRNN_combined_AND_intermediate-finalSRNNlow_AND_intermediate-finalSRNN_combined_combined_combined']
-  
   l_zCol = ['acceptance',
             'N_sig',
             'N_sig_raw',
@@ -61,61 +58,30 @@ def main():
             ]
   
   l_zCol = ['sum_chiSqSyst1pc']
-
-  l_cut_sels = [
-          'resolved-finalSRNNlam_m20', 
-          'intermediate-finalSRNNlam_m20',    
-          'boosted-finalSRNNlam_m20', 
-          'resolved-finalSRNNlam_m10', 
-          'intermediate-finalSRNNlam_m10',    
-          'boosted-finalSRNNlam_m10',
-          'resolved-finalSRNNlam_m7', 
-          'intermediate-finalSRNNlam_m7',    
-          'boosted-finalSRNNlam_m7',
-          'resolved-finalSRNNlam_m5', 
-          'intermediate-finalSRNNlam_m5',    
-          'boosted-finalSRNNlam_m5', 
-          'resolved-finalSRNNlam_m2', 
-          'intermediate-finalSRNNlam_m2',    
-          'boosted-finalSRNNlam_m2', 
-          'resolved-finalSRNNlam_m1', 
-          'intermediate-finalSRNNlam_m1',    
-          'boosted-finalSRNNlam_m1',
-          'resolved-finalSRNNlam0p5', 
-          'intermediate-finalSRNNlam0p5',    
-          'boosted-finalSRNNlam0p5', 
-          'resolved-finalSRNN', 
-          'intermediate-finalSRNN',    
-          'boosted-finalSRNN',
-          'resolved-finalSRNNlam2', 
-          'intermediate-finalSRNNlam2',    
-          'boosted-finalSRNNlam2',
-          'resolved-finalSRNNlam3', 
-          'intermediate-finalSRNNlam3',    
-          'boosted-finalSRNNlam3', 
-          'resolved-finalSRNNlam5', 
-          'intermediate-finalSRNNlam5',    
-          'boosted-finalSRNNlam5', 
-          'resolved-finalSRNNlam7', 
-          'intermediate-finalSRNNlam7',    
-          'boosted-finalSRNNlam7', 
-          'resolved-finalSRNNlam10', 
-          'intermediate-finalSRNNlam10',    
-          'boosted-finalSRNNlam10', 
-          'resolved-finalSRNNlam20', 
-          'intermediate-finalSRNNlam20',    
-          'boosted-finalSRNNlam20'
-  ]
   
   l_cut_sels = [
-                'resolved-finalSR',        'intermediate-finalSR',        'boosted-finalSR',
-                'resolved-finalSRNN',      'intermediate-finalSRNN',      'boosted-finalSRNN',
-                'resolved-finalSRNNlam10', 'intermediate-finalSRNNlam10', 'boosted-finalSRNNlam10',
-                'resolved-finalSR_intermediate-finalSR_boosted-finalSR_combined',
-                'resolved-finalSRNN_intermediate-finalSRNN_boosted-finalSRNN_combined'
+                'SR_res_multibin_combined', 
+                'SR_int_multibin_combined', 
+                'SR_bst_multibin_combined', 
+                'SR_all_multibin_combined',
+
+                'SRNN_res_multibin_lam1_combined', 
+                'SRNN_int_multibin_lam1_combined', 
+                'SRNN_bst_multibin_lam1_combined', 
+                'SRNN_all_multibin_lam1_combined',
+
+                'SRNN_res_multibin_lam5_combined', 
+                'SRNN_int_multibin_lam5_combined', 
+                'SRNN_bst_multibin_lam5_combined', 
+                'SRNN_all_multibin_lam5_combined',
+
+                'SRNN_res_multibin_lam10_combined', 
+                'SRNN_int_multibin_lam10_combined', 
+                'SRNN_bst_multibin_lam10_combined', 
+                'SRNN_all_multibin_lam10_combined',
                 ]
 
-  l_zCol = ['chiSqSyst1pc']
+  l_zCol = ['sum_chiSqSyst0p3pc']
   # ------------------------------------------------------
   # Threshold we want to plot excluded vs viable points
   # ------------------------------------------------------
@@ -137,7 +103,7 @@ def main():
     'chiSq'             : {'zMin':0.001, 'zMax':1e3, 'palette':'kTemperatureMap', 'tlatex':'#chi^{2}'},# = (S #minus S_{SM})^{2} / B'},
     'chiSqSyst1pc'      : {'zMin':0.001, 'zMax':1e3, 'palette':'kTemperatureMap', 'tlatex':'#chi^{2}'},#_{syst} = (S #minus S_{SM})^{2} / (B + (1%B)^{2})'},
     'chiSqSyst5pc'      : {'zMin':0.001, 'zMax':1e3, 'palette':'kTemperatureMap', 'tlatex':'#chi^{2}'},#_{syst} = (S #minus S_{SM})^{2} / (B + (5%B)^{2})'},
-    'sum_chiSqSyst1pc'  : {'zMin':0.001, 'zMax':1e3, 'palette':'kTemperatureMap', 'tlatex':'#chi^{2}'},
+    'sum_chiSqSyst0p3pc'  : {'zMin':0.001, 'zMax':1e3, 'palette':'kTemperatureMap', 'tlatex':'#chi^{2}'},
   }
 
   xCol, yCol = 'SlfCoup', 'TopYuk'
@@ -146,8 +112,7 @@ def main():
     for zCol in l_zCol: 
 
       if 'combine' in cut_sel: 
-        in_file = 'data/CHISQ_loose_preselection_{0}_{1}.csv'.format(cut_sel, zCol)
-        zCol = 'sum_' + zCol
+        in_file = 'data/CHISQ_loose_preselection_{0}_{1}.csv'.format(cut_sel, zCol).replace('sum_', '')
       else:
         in_file = 'data/CHISQ_loose_preselection_{0}.csv'.format(cut_sel)
       out_file = 'contours/limit2d_{0}_SlfCoup_TopYuk_{1}.csv'.format(cut_sel, zCol)
@@ -315,6 +280,8 @@ def draw_contour_with_points(d_csv, out_file, xCol, yCol, zCol, zThreshold, cut_
     syst_txt = ', #zeta_{b} = 0'
   if 'chiSqSyst1pc' in zCol:
     syst_txt = ', #zeta_{b} = 0.01'
+  if 'chiSqSyst0p3pc' in zCol:
+    syst_txt = ', 0.3% syst'
   else:
     syst_txt = ''
 
@@ -330,9 +297,12 @@ def draw_contour_with_points(d_csv, out_file, xCol, yCol, zCol, zThreshold, cut_
   if 'SRNN' in out_file:
     analysis += ' DNN'
     # Add some text to bookkeep which DNN training we're using
-    klambda = cut_sel.split('SRNN')[1].replace('lam', 'DNN trained on #kappa(#lambda_{hhh}) = ').replace('_m', '#minus')
-    print cut_sel, cut_sel.split('SRNN'), klambda
-    if not klambda: klambda = 'DNN trained on #kappa(#lambda_{hhh}) = 1'
+    if 'lam1' in cut_sel: 
+      klambda = 'DNN trained on #kappa(#lambda_{hhh}) = 1'
+    if 'lam5' in cut_sel: 
+      klambda = 'DNN trained on #kappa(#lambda_{hhh}) = 5'
+    if 'lam10' in cut_sel: 
+      klambda = 'DNN trained on #kappa(#lambda_{hhh}) = 10'
     myText(0.07, 0.06, klambda, 0.03, kGray+2, 0, True)
   else:
     analysis += ' Baseline'

--- a/analysis/plotting/combine_chiSq.py
+++ b/analysis/plotting/combine_chiSq.py
@@ -31,40 +31,200 @@ def main():
   my_dir = 'loose_preselection' 
   #
   # ------------------------------------------------------
-  # Input SRs to combine
-  l_SR        = ['resolved-finalSR','intermediate-finalSR','boosted-finalSR']
-  l_SRNN      = ['resolved-finalSRNN','intermediate-finalSRNN','boosted-finalSRNN']
-  l_SRNNlam10 = ['resolved-finalSRNNlam10','intermediate-finalSRNNlam10','boosted-finalSRNNlam10']
   #
   # Column header whose value we want to combine
   #
-  l_to_sum_vars = ['chiSq', 'chiSqSyst0p5pc', 'chiSqSyst1pc']
+  l_to_sum_vars = ['chiSq', 'chiSqSyst0p3pc']#, 'chiSqSyst1pc']
+ 
+  d_SR_sets = {
+    # Inclusive baseline 
+    'SR'        : ['SR-res',
+                   'SR-int',
+                   'SR-bst'],
 
-  for var in l_to_sum_vars:
-    combine_set_of_SRs( l_SR,        var, my_dir )
-    combine_set_of_SRs( l_SRNN,      var, my_dir )
-    combine_set_of_SRs( l_SRNNlam10, var, my_dir )
+    # Multibin baseline (no DNN)
+    'SR_res_multibin' : [
+                'SR-res-200mHH250',
+                'SR-res-250mHH300',
+                'SR-res-300mHH350',
+                'SR-res-350mHH400',
+                'SR-res-400mHH500',
+                'SR-res-500mHH',
+    ],
+                
+    'SR_int_multibin' : [
+                'SR-int-200mHH400',
+                'SR-int-400mHH600',
+                'SR-int-600mHH',
+    ],
+                
+    'SR_bst_multibin' : [
+                'SR-bst-500mHH700',
+                'SR-bst-700mHH900',
+                'SR-bst-900mHH',
+               ],
+
+    'SR_all_multibin' : [
+                'SR-res-200mHH250',
+                'SR-res-250mHH300',
+                'SR-res-300mHH350',
+                'SR-res-350mHH400',
+                'SR-res-400mHH500',
+                'SR-res-500mHH',
+                
+                'SR-int-200mHH400',
+                'SR-int-400mHH600',
+                'SR-int-600mHH',
+                
+                'SR-bst-500mHH700',
+                'SR-bst-700mHH900',
+                'SR-bst-900mHH',
+               ],
+                
+    # Multibin baseline with DNN cut trained on k(lambda)=1
+    'SRNN_res_multibin_lam1' : [
+                'SRNN-res-200mHH250-lam1',
+                'SRNN-res-250mHH300-lam1',
+                'SRNN-res-300mHH350-lam1',
+                'SRNN-res-350mHH400-lam1',
+                'SRNN-res-400mHH500-lam1',
+                'SRNN-res-500mHH-lam1',
+    ],
+                
+    'SRNN_int_multibin_lam1' : [
+                'SRNN-int-200mHH400-lam1',
+                'SRNN-int-400mHH600-lam1',
+                'SRNN-int-600mHH-lam1',
+    ],
+
+    'SRNN_bst_multibin_lam1' : [
+                'SRNN-bst-500mHH700-lam1',
+                'SRNN-bst-700mHH900-lam1',
+                'SRNN-bst-900mHH-lam1', 
+                ],
+    
+    
+    'SRNN_all_multibin_lam1' : [
+                'SRNN-res-200mHH250-lam1',
+                'SRNN-res-250mHH300-lam1',
+                'SRNN-res-300mHH350-lam1',
+                'SRNN-res-350mHH400-lam1',
+                'SRNN-res-400mHH500-lam1',
+                'SRNN-res-500mHH-lam1',
+
+                'SRNN-int-200mHH400-lam1',
+                'SRNN-int-400mHH600-lam1',
+                'SRNN-int-600mHH-lam1',
+
+                'SRNN-bst-500mHH700-lam1',
+                'SRNN-bst-700mHH900-lam1',
+                'SRNN-bst-900mHH-lam1', 
+                ],
+
+    # Multibin baseline with DNN cut trained on k(lambda)=5
+    'SRNN_res_multibin_lam5' : [
+                'SRNN-res-200mHH250-lam5',
+                'SRNN-res-250mHH300-lam5',
+                'SRNN-res-300mHH350-lam5',
+                'SRNN-res-350mHH400-lam5',
+                'SRNN-res-400mHH500-lam5',
+                'SRNN-res-500mHH-lam5',
+    ],
+                
+    'SRNN_int_multibin_lam5' : [
+                'SRNN-int-200mHH400-lam5',
+                'SRNN-int-400mHH600-lam5',
+                'SRNN-int-600mHH-lam5',
+    ],
+
+    'SRNN_bst_multibin_lam5' : [
+                'SRNN-bst-500mHH700-lam5',
+                'SRNN-bst-700mHH900-lam5',
+                'SRNN-bst-900mHH-lam5', 
+                ],
+    
+    
+    'SRNN_all_multibin_lam5' : [
+                'SRNN-res-200mHH250-lam5',
+                'SRNN-res-250mHH300-lam5',
+                'SRNN-res-300mHH350-lam5',
+                'SRNN-res-350mHH400-lam5',
+                'SRNN-res-400mHH500-lam5',
+                'SRNN-res-500mHH-lam5',
+
+                'SRNN-int-200mHH400-lam5',
+                'SRNN-int-400mHH600-lam5',
+                'SRNN-int-600mHH-lam5',
+
+                'SRNN-bst-500mHH700-lam5',
+                'SRNN-bst-700mHH900-lam5',
+                'SRNN-bst-900mHH-lam5', 
+                ],
+
+    # Multibin baseline with DNN cut trained on k(lambda)=10
+    'SRNN_res_multibin_lam10' : [
+                'SRNN-res-200mHH250-lam10',
+                'SRNN-res-250mHH300-lam10',
+                'SRNN-res-300mHH350-lam10',
+                'SRNN-res-350mHH400-lam10',
+                'SRNN-res-400mHH500-lam10',
+                'SRNN-res-500mHH-lam10',
+    ],
+                
+    'SRNN_int_multibin_lam10' : [
+                'SRNN-int-200mHH400-lam10',
+                'SRNN-int-400mHH600-lam10',
+                'SRNN-int-600mHH-lam10',
+    ],
+
+    'SRNN_bst_multibin_lam10' : [
+                'SRNN-bst-500mHH700-lam10',
+                'SRNN-bst-700mHH900-lam10',
+                'SRNN-bst-900mHH-lam10', 
+                ],
+    
+    
+    'SRNN_all_multibin_lam10' : [
+                'SRNN-res-200mHH250-lam10',
+                'SRNN-res-250mHH300-lam10',
+                'SRNN-res-300mHH350-lam10',
+                'SRNN-res-350mHH400-lam10',
+                'SRNN-res-400mHH500-lam10',
+                'SRNN-res-500mHH-lam10',
+
+                'SRNN-int-200mHH400-lam10',
+                'SRNN-int-400mHH600-lam10',
+                'SRNN-int-600mHH-lam10',
+
+                'SRNN-bst-500mHH700-lam10',
+                'SRNN-bst-700mHH900-lam10',
+                'SRNN-bst-900mHH-lam10', 
+                ]
+  }
+
+  for SR_set in d_SR_sets:
+    combine_set_of_SRs( SR_set, d_SR_sets, 'chiSq_ij_Sys0p3pc', my_dir, True )
+    for var in l_to_sum_vars:    
+      combine_set_of_SRs( SR_set, d_SR_sets, var, my_dir )
   
-  combine_set_of_SRs( l_SR,        'chiSq_ij_Sys1pc', my_dir, True )
-  combine_set_of_SRs( l_SRNN,      'chiSq_ij_Sys1pc', my_dir, True )
-  combine_set_of_SRs( l_SRNNlam10, 'chiSq_ij_Sys1pc', my_dir, True )
-
 #____________________________________________________________________________
-def combine_set_of_SRs(l_SRs, to_sum_var, my_dir, do_2dlambda=False):
+def combine_set_of_SRs(SR_set, d_SR_sets, to_sum_var, my_dir, do_2dlambda=False):
   
   # Join SRs as the combined name output
   if do_2dlambda:
-    out_file = 'data/CHISQ_2Dlambda_{0}_{1}_combined_{2}.csv'.format(my_dir, '_'.join(l_SRs), to_sum_var)
+    out_file = 'data/CHISQ_2Dlambda_{0}_{1}_combined_{2}.csv'.format(my_dir, SR_set, to_sum_var)
   else:
-    out_file = 'data/CHISQ_{0}_{1}_combined_{2}.csv'.format(my_dir, '_'.join(l_SRs), to_sum_var)
+    #out_file = 'data/CHISQ_{0}_{1}_combined_{2}.csv'.format(my_dir, '_'.join(l_SRs), to_sum_var)
+    out_file = 'data/CHISQ_{0}_{1}_combined_{2}.csv'.format(my_dir, SR_set, to_sum_var)
 
   #
   # Columns to delete in new dataframe 
   l_del = ['N_bkg','N_sig','N_sig_raw',
-    'SoverB','SoverSqrtB','SoverSqrtBSyst1pc','SoverSqrtBSyst5pc',
-    'chiSq','chiSqSyst1pc','chiSqSyst0p5pc','acceptance','xsec'] 
-  #  
-  # ------------------------------------------------------
+    'SoverB','SoverSqrtB','SoverSqrtBSyst1pc','SoverSqrtBSyst0p3pc',
+    'chiSq','chiSqSyst1pc','chiSqSyst0p3pc','acceptance','xsec'] 
+  
+  # Get the list of SRs to combine
+  l_SRs = d_SR_sets[SR_set]
   
   print('-----------------------------------\n')
   print('List of SRs to combine:')

--- a/analysis/plotting/contours_to_summary.py
+++ b/analysis/plotting/contours_to_summary.py
@@ -35,24 +35,31 @@ def main():
   # ------------------------------------------------------
   
   l_contours = [
-  'boosted-finalSR',
-  'intermediate-finalSR', 
-  'resolved-finalSR', 
-  'resolved-finalSR_intermediate-finalSR_boosted-finalSR_combined',
-  'boosted-finalSRNN',
-  'intermediate-finalSRNN', 
-  'resolved-finalSRNN', 
-  'resolved-finalSRNN_intermediate-finalSRNN_boosted-finalSRNN_combined']
+      'SR_res_multibin_combined', 
+      'SR_int_multibin_combined', 
+      'SR_bst_multibin_combined', 
+      'SR_all_multibin_combined',
+
+      'SRNN_res_multibin_lam1_combined', 
+      'SRNN_int_multibin_lam1_combined', 
+      'SRNN_bst_multibin_lam1_combined', 
+      'SRNN_all_multibin_lam1_combined',
+
+      #'SRNN_all_multibin_lam5_combined',
+      #'SRNN_all_multibin_lam10_combined'
+  ]
   
   d_tlatex = {
-    'resolved-finalSR'       : 'Resolved',
-    'intermediate-finalSR'   : 'Intermediate',
-    'boosted-finalSR'        : 'Boosted',
-    'resolved-finalSRNN'     : 'Resolved',
-    'intermediate-finalSRNN' : 'Intermediate',
-    'boosted-finalSRNN'      : 'Boosted',
-    'resolved-finalSR_intermediate-finalSR_boosted-finalSR_combined'       : 'Combined',
-    'resolved-finalSRNN_intermediate-finalSRNN_boosted-finalSRNN_combined' : 'Combined'
+    'SR_res_multibin_combined'         : 'Resolved',
+    'SR_int_multibin_combined'         : 'Intermediate',
+    'SR_bst_multibin_combined'         : 'Boosted',
+    'SR_all_multibin_combined'         : 'Combined',
+    'SRNN_res_multibin_lam1_combined'  : 'Resolved',
+    'SRNN_int_multibin_lam1_combined'  : 'Intermediate',
+    'SRNN_bst_multibin_lam1_combined'  : 'Boosted',
+    'SRNN_all_multibin_lam1_combined'  : 'Combined',
+    'SRNN_all_multibin_lam5_combined'  : 'Combined #kappa(#lambda_{hhh}) = 5',
+    'SRNN_all_multibin_lam10_combined' : 'Combined #kappa(#lambda_{hhh}) = 10',
   }
 
   xCol, yCol = 'x', 'y'
@@ -70,7 +77,7 @@ def main():
     
     
     if 'combined' in contour:
-      in_file = 'contours/limit2d_{0}_SlfCoup_TopYuk_sum_chiSqSyst1pc.csv'.format(contour)
+      in_file = 'contours/limit2d_{0}_SlfCoup_TopYuk_sum_chiSqSyst0p3pc.csv'.format(contour)
     else:
       in_file = 'contours/limit2d_{0}_SlfCoup_TopYuk_chiSqSyst1pc.csv'.format(contour)
     print('Reading: {0}'.format(in_file))
@@ -163,9 +170,9 @@ def mk_plot(l_contours, d_tg, save_name, d_tlatex):
   #-------------------------------------------------
   # Construct and add plots to legend
   #-------------------------------------------------
-  xl1=0.57
-  yl1=0.23
-  xl2=xl1+0.20
+  xl1=0.26
+  yl1=0.62
+  xl2=xl1+0.15
   yl2=yl1+0.17
   # Blues baseline
   leg = TLegend(xl1,yl1,xl2,yl2)
@@ -218,13 +225,13 @@ def mk_plot(l_contours, d_tg, save_name, d_tlatex):
   # Text
   #-------------------------------------------------
   # Extra text
-  top_txt = 'hh #rightarrow 4b, 68% CL contours, 1% systematics'
+  top_txt = 'hh #rightarrow 4b, 68% CL contours, 0.3% systematics'
   # Text at top
   myText(0.18, 0.91, SQRTS_LUMI + ', ' + top_txt, 0.040, kBlack, 0, True)
 
   # Add text to plot interior
-  myText(0.510, 0.41, 'DNN', 0.035, kBlack, 0, True)
-  myText(0.575, 0.41, 'Baseline', 0.035, kBlack, 0, True)
+  myText(0.20, 0.80, 'DNN', 0.035, kBlack, 0, True)
+  myText(0.27, 0.80, 'Baseline', 0.035, kBlack, 0, True)
   myText(0.60, 0.55,  'SM', 0.04, kGray+2, 0, True)
   
   gPad.RedrawAxis()

--- a/analysis/plotting/cuts.py
+++ b/analysis/plotting/cuts.py
@@ -66,76 +66,47 @@ def configure_cuts(cut_sel, print_cuts=True):
               'h1_M > 50',
               'h2_M > 50',
               ]
-  #jesse_intermediate: ['n_large_jets == 1',
-  #                       'pT_h1 > 200',
-  #                       'n_small_jets >= 2',
-  #                       'n_assoc_track_jets >= 2',
-  #                       'n_assoc_track_tag >= 2',
-  #                       'n_small_tag >= 1'
-  #                       ]
-  l_SR_resolved     = l_common + l_resolved     + l_resolved_SR 
-  l_SR_intermediate = l_common + l_intermediate + l_intermediate_SR 
-  l_SR_boosted      = l_common + l_boosted      + l_boosted_SR 
 
-  l_NN_lambda_m20 = ['nnscore_SlfCoup_m20.0_qcd < 0.2', 
-                     'nnscore_SlfCoup_m20.0_top < 0.2', 
-                     'nnscore_SlfCoup_m20.0_sig > 0.85']
+  # Binning for resolved
+  l_200mHH250  = ['m_hh > 200 && m_hh < 250']
+  l_250mHH300  = ['m_hh > 250 && m_hh < 300']
+  l_300mHH350  = ['m_hh > 300 && m_hh < 350']
+  l_350mHH400  = ['m_hh > 350 && m_hh < 400']
+  l_400mHH500  = ['m_hh > 400 && m_hh < 500']
+  l_500mHH     = ['m_hh > 500']
+  
+  # Binning for intermediate
+  l_200mHH400  = ['m_hh > 200 && m_hh < 400']
+  l_400mHH600  = ['m_hh > 400 && m_hh < 600']
+  l_600mHH     = ['m_hh > 600']
+  
+  # Binning for boosted
+  l_500mHH700  = ['m_hh > 500 && m_hh < 700']
+  l_700mHH900  = ['m_hh > 700 && m_hh < 900']
+  l_900mHH     = ['m_hh > 900']
 
-  l_NN_lambda_m10 = ['nnscore_SlfCoup_m10.0_qcd < 0.2', 
-                     'nnscore_SlfCoup_m10.0_top < 0.2', 
-                     'nnscore_SlfCoup_m10.0_sig > 0.85']
+  # Single cuts on DNN score
+  l_NNlamM20  = ['nnscore_SlfCoup_m20.0_sig > 0.85']
+  l_NNlamM10  = ['nnscore_SlfCoup_m10.0_sig > 0.85']
+  l_NNlamM7   = ['nnscore_SlfCoup_m7.0_sig  > 0.85']
+  l_NNlamM5   = ['nnscore_SlfCoup_m5.0_sig  > 0.85']
+  l_NNlamM2   = ['nnscore_SlfCoup_m2.0_sig  > 0.85']
+  l_NNlamM1   = ['nnscore_SlfCoup_m1.0_sig  > 0.85']
+  l_NNlamM0p5 = ['nnscore_SlfCoup_m0.5_sig  > 0.85']
 
-  l_NN_lambda_m7 = ['nnscore_SlfCoup_m7.0_qcd < 0.2', 
-                    'nnscore_SlfCoup_m7.0_top < 0.2', 
-                    'nnscore_SlfCoup_m7.0_sig > 0.85']
+  l_NNlam0p5  = ['nnscore_SlfCoup_0.5_sig   > 0.85']
+  l_NNlam1    = ['nnscore_SlfCoup_1.0_sig  > 0.85']
+  l_NNlam2    = ['nnscore_SlfCoup_2.0_sig  > 0.85']
+  l_NNlam3    = ['nnscore_SlfCoup_3.0_sig  > 0.85']
+  l_NNlam5    = ['nnscore_SlfCoup_5.0_sig  > 0.85']
+  l_NNlam7    = ['nnscore_SlfCoup_7.0_sig  > 0.85']
+  l_NNlam10   = ['nnscore_SlfCoup_10.0_sig > 0.85']
+  l_NNlam20   = ['nnscore_SlfCoup_20.0_sig > 0.85']
 
-  l_NN_lambda_m5 = ['nnscore_SlfCoup_m5.0_qcd < 0.2', 
-                    'nnscore_SlfCoup_m5.0_top < 0.2', 
-                    'nnscore_SlfCoup_m5.0_sig > 0.85']
-
-  l_NN_lambda_m2 = ['nnscore_SlfCoup_m2.0_qcd < 0.2', 
-                    'nnscore_SlfCoup_m2.0_top < 0.2', 
-                    'nnscore_SlfCoup_m2.0_sig > 0.85']
-
-  l_NN_lambda_m1 = ['nnscore_SlfCoup_m1.0_qcd < 0.2', 
-                    'nnscore_SlfCoup_m1.0_top < 0.2', 
-                    'nnscore_SlfCoup_m1.0_sig > 0.85']
-
-  l_NN_lambda_m0p5 = ['nnscore_SlfCoup_m0.5_qcd < 0.2', 
-                      'nnscore_SlfCoup_m0.5_top < 0.2', 
-                      'nnscore_SlfCoup_m0.5_sig > 0.85']
-
-  l_NN_lambda_0p5=['nnscore_SlfCoup_0.5_qcd < 0.2', 
-                   'nnscore_SlfCoup_0.5_top < 0.2', 
-                   'nnscore_SlfCoup_0.5_sig > 0.85']
-
-  l_NN_lambda_1  = ['nnscore_SlfCoup_1.0_qcd < 0.2', 
-                    'nnscore_SlfCoup_1.0_top < 0.2', 
-                    'nnscore_SlfCoup_1.0_sig > 0.85']
-
-  l_NN_lambda_2  = ['nnscore_SlfCoup_2.0_qcd < 0.2', 
-                    'nnscore_SlfCoup_2.0_top < 0.2', 
-                    'nnscore_SlfCoup_2.0_sig > 0.85']
-
-  l_NN_lambda_3  = ['nnscore_SlfCoup_3.0_qcd < 0.2', 
-                    'nnscore_SlfCoup_3.0_top < 0.2', 
-                    'nnscore_SlfCoup_3.0_sig > 0.85']
-
-  l_NN_lambda_5  = ['nnscore_SlfCoup_5.0_qcd < 0.2', 
-                    'nnscore_SlfCoup_5.0_top < 0.2', 
-                    'nnscore_SlfCoup_5.0_sig > 0.85']
-
-  l_NN_lambda_7  = ['nnscore_SlfCoup_7.0_qcd < 0.2', 
-                    'nnscore_SlfCoup_7.0_top < 0.2', 
-                    'nnscore_SlfCoup_7.0_sig > 0.85']
-
-  l_NN_lambda_10 = ['nnscore_SlfCoup_10.0_qcd < 0.2', 
-                    'nnscore_SlfCoup_10.0_top < 0.2', 
-                    'nnscore_SlfCoup_10.0_sig > 0.85']
-
-  l_NN_lambda_20 = ['nnscore_SlfCoup_20.0_qcd < 0.2', 
-                    'nnscore_SlfCoup_20.0_top < 0.2', 
-                    'nnscore_SlfCoup_20.0_sig > 0.85']
+  # Define final inclusive SRs for 3 channels
+  l_SR_res = l_common + l_resolved     + l_resolved_SR 
+  l_SR_int = l_common + l_intermediate + l_intermediate_SR 
+  l_SR_bst = l_common + l_boosted      + l_boosted_SR 
 
 
   # =============================================
@@ -151,105 +122,95 @@ def configure_cuts(cut_sel, print_cuts=True):
     'intermediate-commonSR'     : l_common + l_intermediate,
     'boosted-commonSR'          : l_common + l_boosted,
 
-    'resolved-finalSR'          : l_common + l_resolved     + l_resolved_SR,
-    'intermediate-finalSR'      : l_common + l_intermediate + l_intermediate_SR,
-    'boosted-finalSR'           : l_common + l_boosted      + l_boosted_SR,
+    # Inclusive SRs (no multibin)
+    'SR-res' : l_SR_res,
+    'SR-int' : l_SR_int,
+    'SR-bst' : l_SR_bst,
+    # DNN trained on k(lambda) = 1
+    'SRNN-res' : l_SR_res + l_NNlam1,
+    'SRNN-int' : l_SR_int + l_NNlam1,
+    'SRNN-bst' : l_SR_bst + l_NNlam1,
+    
+    #------------------------------------------------
+    # Baseline analysis
+    # Resolved multibin baseline
+    'SR-res-200mHH250' : l_SR_res + l_200mHH250,
+    'SR-res-250mHH300' : l_SR_res + l_250mHH300,
+    'SR-res-300mHH350' : l_SR_res + l_300mHH350,
+    'SR-res-350mHH400' : l_SR_res + l_350mHH400,
+    'SR-res-400mHH500' : l_SR_res + l_400mHH500,
+    'SR-res-500mHH'    : l_SR_res + l_500mHH,
 
-    'resolved-finalSRNNQCD'     : l_common + l_resolved     + l_resolved_SR +     ['nnscore_SlfCoup_1.0_qcd < 0.2'],
-    'intermediate-finalSRNNQCD' : l_common + l_intermediate + l_intermediate_SR + ['nnscore_SlfCoup_1.0_qcd < 0.2'],
-    'boosted-finalSRNNQCD'      : l_common + l_boosted      + l_boosted_SR +      ['nnscore_SlfCoup_1.0_qcd < 0.2'],
+    # Intermediate multibin baseline
+    'SR-int-200mHH400' : l_SR_int + l_200mHH400,
+    'SR-int-400mHH600' : l_SR_int + l_400mHH600,
+    'SR-int-600mHH'    : l_SR_int + l_600mHH,
 
-    'resolved-finalSRNNQCDTop'     : l_common + l_resolved     + l_resolved_SR +     ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.2'],
-    'intermediate-finalSRNNQCDTop' : l_common + l_intermediate + l_intermediate_SR + ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'],
-    'boosted-finalSRNNQCDTop'      : l_common + l_boosted      + l_boosted_SR +      ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'],
+    # Boosted multibin baseline
+    'SR-bst-500mHH700' : l_SR_bst + l_500mHH700,
+    'SR-bst-700mHH900' : l_SR_bst + l_700mHH900,
+    'SR-bst-900mHH'    : l_SR_bst + l_900mHH,
 
-    'resolved-finalSRNNlow'     : l_common + l_resolved +     l_resolved_SR +     ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.2'] + ['nnscore_SlfCoup_1.0_sig <= 0.85'],
-    'intermediate-finalSRNNlow' : l_common + l_intermediate + l_intermediate_SR + ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'] + ['nnscore_SlfCoup_1.0_sig <= 0.85'],
-    'boosted-finalSRNNlow'      : l_common + l_boosted +      l_boosted_SR +      ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'] + ['nnscore_SlfCoup_1.0_sig <= 0.85'],
+    #------------------------------------------------
+    # DNN trained on k(lambda) = 1
+    # Resolved multibin DNN
+    'SRNN-res-200mHH250-lam1' : l_SR_res + l_200mHH250 + l_NNlam1,
+    'SRNN-res-250mHH300-lam1' : l_SR_res + l_250mHH300 + l_NNlam1,
+    'SRNN-res-300mHH350-lam1' : l_SR_res + l_300mHH350 + l_NNlam1,
+    'SRNN-res-350mHH400-lam1' : l_SR_res + l_350mHH400 + l_NNlam1,
+    'SRNN-res-400mHH500-lam1' : l_SR_res + l_400mHH500 + l_NNlam1,
+    'SRNN-res-500mHH-lam1'    : l_SR_res + l_500mHH    + l_NNlam1,
 
-    'resolved-finalSRNN'        : l_common + l_resolved +     l_resolved_SR +     ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.2'] + ['nnscore_SlfCoup_1.0_sig > 0.85'],
-    'intermediate-finalSRNN'    : l_common + l_intermediate + l_intermediate_SR + ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'] + ['nnscore_SlfCoup_1.0_sig > 0.85'],
-    'boosted-finalSRNN'         : l_common + l_boosted +      l_boosted_SR +      ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'] + ['nnscore_SlfCoup_1.0_sig > 0.85'],
+    # Intermediate multibin DNN
+    'SRNN-int-200mHH400-lam1' : l_SR_int + l_200mHH400 + l_NNlam1,
+    'SRNN-int-400mHH600-lam1' : l_SR_int + l_400mHH600 + l_NNlam1,
+    'SRNN-int-600mHH-lam1'    : l_SR_int + l_600mHH    + l_NNlam1,
 
-    'resolved-finalSRNNlamm5'        : l_common + l_resolved +     l_resolved_SR +     ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.2'] + ['nnscore_SlfCoup_m5.0_sig > 0.85'],
-    'intermediate-finalSRNNlamm5'    : l_common + l_intermediate + l_intermediate_SR + ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'] + ['nnscore_SlfCoup_m5.0_sig > 0.85'],
-    'boosted-finalSRNNlamm5'         : l_common + l_boosted +      l_boosted_SR +      ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'] + ['nnscore_SlfCoup_m5.0_sig > 0.85'],
+    # Boosted multibin DNN
+    'SRNN-bst-500mHH700-lam1' : l_SR_bst + l_500mHH700 + l_NNlam1,
+    'SRNN-bst-700mHH900-lam1' : l_SR_bst + l_700mHH900 + l_NNlam1,
+    'SRNN-bst-900mHH-lam1'    : l_SR_bst + l_900mHH    + l_NNlam1,
 
-    'resolved-finalSRNNlam10'        : l_common + l_resolved +     l_resolved_SR +     ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.2'] + ['nnscore_SlfCoup_10.0_sig > 0.85'],
-    'intermediate-finalSRNNlam10'    : l_common + l_intermediate + l_intermediate_SR + ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'] + ['nnscore_SlfCoup_10.0_sig > 0.85'],
-    'boosted-finalSRNNlam10'         : l_common + l_boosted +      l_boosted_SR +      ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'] + ['nnscore_SlfCoup_10.0_sig > 0.85'],
+    #------------------------------------------------
+    # DNN trained on k(lambda) = 5
+    # Resolved multibin DNN lam5
+    'SRNN-res-200mHH250-lam5' : l_SR_res + l_200mHH250 + l_NNlam5,
+    'SRNN-res-250mHH300-lam5' : l_SR_res + l_250mHH300 + l_NNlam5,
+    'SRNN-res-300mHH350-lam5' : l_SR_res + l_300mHH350 + l_NNlam5,
+    'SRNN-res-350mHH400-lam5' : l_SR_res + l_350mHH400 + l_NNlam5,
+    'SRNN-res-400mHH500-lam5' : l_SR_res + l_400mHH500 + l_NNlam5,
+    'SRNN-res-500mHH-lam5'    : l_SR_res + l_500mHH    + l_NNlam5,
 
-    'resolved-finalSRNNlam10low'        : l_common + l_resolved +     l_resolved_SR +     ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.2'] + ['nnscore_SlfCoup_10.0_sig <= 0.85'],
-    'intermediate-finalSRNNlam10low'    : l_common + l_intermediate + l_intermediate_SR + ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'] + ['nnscore_SlfCoup_10.0_sig <= 0.85'],
-    'boosted-finalSRNNlam10low'         : l_common + l_boosted +      l_boosted_SR +      ['nnscore_SlfCoup_1.0_qcd < 0.2'] + ['nnscore_SlfCoup_1.0_top < 0.1'] + ['nnscore_SlfCoup_10.0_sig <= 0.85'],
+    # Intermediate multibin DNN lam5
+    'SRNN-int-200mHH400-lam5' : l_SR_int + l_200mHH400 + l_NNlam5,
+    'SRNN-int-400mHH600-lam5' : l_SR_int + l_400mHH600 + l_NNlam5,
+    'SRNN-int-600mHH-lam5'    : l_SR_int + l_600mHH    + l_NNlam5,
 
-    'resolved-finalSRNNSig'     : l_common + l_resolved     + l_resolved_SR +     ['nnscore_SlfCoup_1.0_sig > 0.6'],
-    'intermediate-finalSRNNSig' : l_common + l_intermediate + l_intermediate_SR + ['nnscore_SlfCoup_1.0_sig > 0.6'],
-    'boosted-finalSRNNSig'      : l_common + l_boosted      + l_boosted_SR +      ['nnscore_SlfCoup_1.0_sig > 0.6'],
+    # Boosted multibin DNN lam5
+    'SRNN-bst-500mHH700-lam5' : l_SR_bst + l_500mHH700 + l_NNlam5,
+    'SRNN-bst-700mHH900-lam5' : l_SR_bst + l_700mHH900 + l_NNlam5,
+    'SRNN-bst-900mHH-lam5'    : l_SR_bst + l_900mHH    + l_NNlam5,
 
-    'resolved-finalSRNNlam_m20'     : l_SR_resolved     + l_NN_lambda_m20,
-    'intermediate-finalSRNNlam_m20' : l_SR_intermediate + l_NN_lambda_m20,
-    'boosted-finalSRNNlam_m20'      : l_SR_boosted      + l_NN_lambda_m20,
+    #------------------------------------------------
+    # DNN trained on k(lambda) = 10
+    # Resolved multibin DNN lam10
+    'SRNN-res-200mHH250-lam10' : l_SR_res + l_200mHH250 + l_NNlam10,
+    'SRNN-res-250mHH300-lam10' : l_SR_res + l_250mHH300 + l_NNlam10,
+    'SRNN-res-300mHH350-lam10' : l_SR_res + l_300mHH350 + l_NNlam10,
+    'SRNN-res-350mHH400-lam10' : l_SR_res + l_350mHH400 + l_NNlam10,
+    'SRNN-res-400mHH500-lam10' : l_SR_res + l_400mHH500 + l_NNlam10,
+    'SRNN-res-500mHH-lam10'    : l_SR_res + l_500mHH    + l_NNlam10,
 
-    'resolved-finalSRNNlam_m10'     : l_SR_resolved     + l_NN_lambda_m10,
-    'intermediate-finalSRNNlam_m10' : l_SR_intermediate + l_NN_lambda_m10,
-    'boosted-finalSRNNlam_m10'      : l_SR_boosted      + l_NN_lambda_m10,
+    # Intermediate multibin DNN lam10
+    'SRNN-int-200mHH400-lam10' : l_SR_int + l_200mHH400 + l_NNlam10,
+    'SRNN-int-400mHH600-lam10' : l_SR_int + l_400mHH600 + l_NNlam10,
+    'SRNN-int-600mHH-lam10'    : l_SR_int + l_600mHH    + l_NNlam10,
 
-    'resolved-finalSRNNlam_m7'     : l_SR_resolved     + l_NN_lambda_m7,
-    'intermediate-finalSRNNlam_m7' : l_SR_intermediate + l_NN_lambda_m7,
-    'boosted-finalSRNNlam_m7'      : l_SR_boosted      + l_NN_lambda_m7,
+    # Boosted multibin DNN lam10
+    'SRNN-bst-500mHH700-lam10' : l_SR_bst + l_500mHH700 + l_NNlam10,
+    'SRNN-bst-700mHH900-lam10' : l_SR_bst + l_700mHH900 + l_NNlam10,
+    'SRNN-bst-900mHH-lam10'    : l_SR_bst + l_900mHH    + l_NNlam10,
 
-    'resolved-finalSRNNlam_m5'     : l_SR_resolved     + l_NN_lambda_m5,
-    'intermediate-finalSRNNlam_m5' : l_SR_intermediate + l_NN_lambda_m5,
-    'boosted-finalSRNNlam_m5'      : l_SR_boosted      + l_NN_lambda_m5,
-
-    'resolved-finalSRNNlam_m2'     : l_SR_resolved     + l_NN_lambda_m2,
-    'intermediate-finalSRNNlam_m2' : l_SR_intermediate + l_NN_lambda_m2,
-    'boosted-finalSRNNlam_m2'      : l_SR_boosted      + l_NN_lambda_m2,
-
-    'resolved-finalSRNNlam_m1'     : l_SR_resolved     + l_NN_lambda_m1,
-    'intermediate-finalSRNNlam_m1' : l_SR_intermediate + l_NN_lambda_m1,
-    'boosted-finalSRNNlam_m1'      : l_SR_boosted      + l_NN_lambda_m1,
-
-    'resolved-finalSRNNlam_m0p5'     : l_SR_resolved     + l_NN_lambda_m0p5,
-    'intermediate-finalSRNNlam_m0p5' : l_SR_intermediate + l_NN_lambda_m0p5,
-    'boosted-finalSRNNlam_m0p5'      : l_SR_boosted      + l_NN_lambda_m0p5,
-
-    'resolved-finalSRNNlam0p5'     : l_SR_resolved     + l_NN_lambda_0p5,
-    'intermediate-finalSRNNlam0p5' : l_SR_intermediate + l_NN_lambda_0p5,
-    'boosted-finalSRNNlam0p5'      : l_SR_boosted      + l_NN_lambda_0p5,
-
-    'resolved-finalSRNN'          : l_SR_resolved     + l_NN_lambda_1,
-    'intermediate-finalSRNN'      : l_SR_intermediate + l_NN_lambda_1,
-    'boosted-finalSRNN'           : l_SR_boosted      + l_NN_lambda_1,
-
-    'resolved-finalSRNNlam2'      : l_SR_resolved     + l_NN_lambda_2,
-    'intermediate-finalSRNNlam2'  : l_SR_intermediate + l_NN_lambda_2,
-    'boosted-finalSRNNlam2'       : l_SR_boosted      + l_NN_lambda_2,
-
-    'resolved-finalSRNNlam3'      : l_SR_resolved     + l_NN_lambda_3,
-    'intermediate-finalSRNNlam3'  : l_SR_intermediate + l_NN_lambda_3,
-    'boosted-finalSRNNlam3'       : l_SR_boosted      + l_NN_lambda_3,
-
-    'resolved-finalSRNNlam5'      : l_SR_resolved     + l_NN_lambda_5,
-    'intermediate-finalSRNNlam5'  : l_SR_intermediate + l_NN_lambda_5,
-    'boosted-finalSRNNlam5'       : l_SR_boosted      + l_NN_lambda_5,
-
-    'resolved-finalSRNNlam7'      : l_SR_resolved     + l_NN_lambda_7,
-    'intermediate-finalSRNNlam7'  : l_SR_intermediate + l_NN_lambda_7,
-    'boosted-finalSRNNlam7'       : l_SR_boosted      + l_NN_lambda_7,
-
-    'resolved-finalSRNNlam10'     : l_SR_resolved     + l_NN_lambda_10,
-    'intermediate-finalSRNNlam10' : l_SR_intermediate + l_NN_lambda_10,
-    'boosted-finalSRNNlam10'      : l_SR_boosted      + l_NN_lambda_10,
-
-    'resolved-finalSRNNlam20'     : l_SR_resolved     + l_NN_lambda_20,
-    'intermediate-finalSRNNlam20' : l_SR_intermediate + l_NN_lambda_20,
-    'boosted-finalSRNNlam20'      : l_SR_boosted      + l_NN_lambda_20,
-
-
-
-    #'SR-1ibsmall-2ibtrk' : l_SR_1ibsmall_2ibtrk,
   } 
   
   l_cuts = [''] 

--- a/analysis/plotting/ntuples_to_chiSq.py
+++ b/analysis/plotting/ntuples_to_chiSq.py
@@ -38,6 +38,12 @@ samp_nom = 'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_1.0'
 
 # Do lambda_i vs lambda_j scan
 do_lambda_ij = True
+  
+# b-tagging improvement factor for 4 b-quarks (hh4b signal, 4b bkg) 
+bTagImprove_4b = 1.36
+
+# 2 b-quarks (2b2j, ttbar bkg)
+bTagImprove_2b = 1.17
 
 #____________________________________________________________________________
 def main():
@@ -55,64 +61,70 @@ def main():
   # Signal region (define in cuts.py)
   l_sig_regs = ['preselection'] 
   # Cut selections
-  l_cut_sels = ['resolved-preselection', 'intermediate-preselection' ,'boosted-preselection',
-                'resolved-commonSR',     'intermediate-commonSR',     'boosted-commonSR',
-                'resolved-finalSR',      'intermediate-finalSR',      'boosted-finalSR', 
-                'resolved-finalSRNN',      'intermediate-finalSRNN',      'boosted-finalSRNN' ] 
-
   l_cut_sels = [
-          'resolved-finalSRNNlam_m20', 
-          'intermediate-finalSRNNlam_m20',    
-          'boosted-finalSRNNlam_m20', 
-          'resolved-finalSRNNlam_m10', 
-          'intermediate-finalSRNNlam_m10',    
-          'boosted-finalSRNNlam_m10',
-          'resolved-finalSRNNlam_m7', 
-          'intermediate-finalSRNNlam_m7',    
-          'boosted-finalSRNNlam_m7',
-          'resolved-finalSRNNlam_m5', 
-          'intermediate-finalSRNNlam_m5',    
-          'boosted-finalSRNNlam_m5', 
-          'resolved-finalSRNNlam_m2', 
-          'intermediate-finalSRNNlam_m2',    
-          'boosted-finalSRNNlam_m2', 
-          'resolved-finalSRNNlam_m1', 
-          'intermediate-finalSRNNlam_m1',    
-          'boosted-finalSRNNlam_m1',
-          'resolved-finalSRNNlam_m0p5', 
-          'intermediate-finalSRNNlam_m0p5',    
-          'boosted-finalSRNNlam_m0p5', 
-          'resolved-finalSRNNlam0p5', 
-          'intermediate-finalSRNNlam0p5',    
-          'boosted-finalSRNNlam0p5', 
-          'resolved-finalSRNN', 
-          'intermediate-finalSRNN',    
-          'boosted-finalSRNN',
-          'resolved-finalSRNNlam2', 
-          'intermediate-finalSRNNlam2',    
-          'boosted-finalSRNNlam2',
-          'resolved-finalSRNNlam3', 
-          'intermediate-finalSRNNlam3',    
-          'boosted-finalSRNNlam3', 
-          'resolved-finalSRNNlam5', 
-          'intermediate-finalSRNNlam5',    
-          'boosted-finalSRNNlam5', 
-          'resolved-finalSRNNlam7', 
-          'intermediate-finalSRNNlam7',    
-          'boosted-finalSRNNlam7', 
-          'resolved-finalSRNNlam10', 
-          'intermediate-finalSRNNlam10',    
-          'boosted-finalSRNNlam10', 
-          'resolved-finalSRNNlam20', 
-          'intermediate-finalSRNNlam20',    
-          'boosted-finalSRNNlam20'
-  ]
+                # Inclusive analyses (no multibin)
+                'SR-res',
+                'SR-int',
+                'SR-bst',
 
-  l_cut_sels = ['resolved-finalSR',      'intermediate-finalSR',      'boosted-finalSR',
-                'resolved-finalSRNN',    'intermediate-finalSRNN',    'boosted-finalSRNN', 
-                'resolved-finalSRNNlam10', 'intermediate-finalSRNNlam10',    'boosted-finalSRNNlam10' ] 
-  #================================================
-  
+                # Multibin baseline (no DNN)
+                'SR-res-200mHH250',
+                'SR-res-250mHH300',
+                'SR-res-300mHH350',
+                'SR-res-350mHH400',
+                'SR-res-400mHH500',
+                'SR-res-500mHH',
+                'SR-int-200mHH400',
+                'SR-int-400mHH600',
+                'SR-int-600mHH',
+                'SR-bst-500mHH700',
+                'SR-bst-700mHH900',
+                'SR-bst-900mHH',
+
+                # Multibin baseline with DNN cut trained on k(lambda) = 1
+                'SRNN-res-200mHH250-lam1',
+                'SRNN-res-250mHH300-lam1',
+                'SRNN-res-300mHH350-lam1',
+                'SRNN-res-350mHH400-lam1',
+                'SRNN-res-400mHH500-lam1',
+                'SRNN-res-500mHH-lam1',
+                'SRNN-int-200mHH400-lam1',
+                'SRNN-int-400mHH600-lam1',
+                'SRNN-int-600mHH-lam1',
+                'SRNN-bst-500mHH700-lam1',
+                'SRNN-bst-700mHH900-lam1',
+                'SRNN-bst-900mHH-lam1',
+
+                # Multibin baseline with DNN cut trained on k(lambda) = 5
+                'SRNN-res-200mHH250-lam5',
+                'SRNN-res-250mHH300-lam5',
+                'SRNN-res-300mHH350-lam5',
+                'SRNN-res-350mHH400-lam5',
+                'SRNN-res-400mHH500-lam5',
+                'SRNN-res-500mHH-lam5',
+                'SRNN-int-200mHH400-lam5',
+                'SRNN-int-400mHH600-lam5',
+                'SRNN-int-600mHH-lam5',
+                'SRNN-bst-500mHH700-lam5',
+                'SRNN-bst-700mHH900-lam5',
+                'SRNN-bst-900mHH-lam5',
+
+                # Multibin baseline with DNN cut trained on k(lambda) = 10
+                'SRNN-res-200mHH250-lam10',
+                'SRNN-res-250mHH300-lam10',
+                'SRNN-res-300mHH350-lam10',
+                'SRNN-res-350mHH400-lam10',
+                'SRNN-res-400mHH500-lam10',
+                'SRNN-res-500mHH-lam10',
+                'SRNN-int-200mHH400-lam10',
+                'SRNN-int-400mHH600-lam10',
+                'SRNN-int-600mHH-lam10',
+                'SRNN-bst-500mHH700-lam10',
+                'SRNN-bst-700mHH900-lam10',
+                'SRNN-bst-900mHH-lam10'
+               ]  
+
+
   # -------------------------------------------------------------
   # Argument parser
   parser = argparse.ArgumentParser(description='Analyse background/signal TTrees and make plots.')
@@ -186,8 +198,8 @@ def do_selection( yield_file, save_file, lumi, sig_reg, cut_sel, samp_nom):
   # ---------------------------------------
   with open(save_file, 'w') as f_out:
     header  = 'TopYuk,SlfCoup,N_bkg,N_sig,N_sig_raw,'
-    header += 'SoverB,SoverSqrtB,SoverSqrtBSyst1pc,SoverSqrtBSyst5pc,'
-    header += 'chiSq,chiSqSyst1pc,chiSqSyst0p5pc,acceptance,xsec\n'
+    header += 'SoverB,SoverSqrtB,SoverSqrtBSyst1pc,SoverSqrtBSyst0p3pc,'
+    header += 'chiSq,chiSqSyst1pc,chiSqSyst0p3pc,acceptance,xsec\n'
     f_out.write( header )
 
     for signal in l_sig_list:  
@@ -210,7 +222,7 @@ def do_selection( yield_file, save_file, lumi, sig_reg, cut_sel, samp_nom):
 
     save_file_2d = save_file.replace('CHISQ_', 'CHISQ_2Dlambda_')
     with open(save_file_2d, 'w') as f_out2d:
-      header2d = 'lambda_i,lambda_j,chiSq_ij_Sys1pc,chiSq_ij\n'
+      header2d = 'lambda_i,lambda_j,chiSq_ij_Sys1pc,chiSq_ij_Sys0p3pc,chiSq_ij\n'
       f_out2d.write( header2d )
 
       for signal_i in l_sig_list:
@@ -226,10 +238,11 @@ def do_selection( yield_file, save_file, lumi, sig_reg, cut_sel, samp_nom):
           lambda_j = float( signal_j.split('_')[7].replace('m', '-') )
           
           # Extract chi squares
-          chiSq       = float(long_out.split(',')[9])
-          chiSqSys1pc = float(long_out.split(',')[10])
+          chiSq         = float(long_out.split(',')[9])
+          chiSqSys1pc   = float(long_out.split(',')[10])
+          chiSqSys0p3pc = float(long_out.split(',')[11])
       
-          out_str = '{0:.1f},{1:.1f},{2:.4g},{3:.4g}\n'.format(lambda_i, lambda_j, chiSqSys1pc, chiSq)
+          out_str = '{0:.1f},{1:.1f},{2:.4g},{3:.4g},{4:.4g}\n'.format(lambda_i, lambda_j, chiSqSys1pc, chiSqSys0p3pc, chiSq)
           f_out2d.write(out_str)
 
   print('\n------------------------------------------------------')
@@ -275,15 +288,32 @@ def apply_cuts_weights_to_tree(f, hname, var, lumi, unweighted_cuts='', Nbins=10
   th1 = TH1D('h_sig', "", Nbins, xmin, xmax) 
   ttree = f.Get('preselection')
 
+  # Normalising number of raw events
   N_raw = f.Get('loose_cutflow').GetBinContent(1)
 
+  # Obtain cross-sections
   d_xsecs = configure_xsecs()
   xsec = d_xsecs[hname]
+ 
+  # Hard-coded k-factors and b-tagging improvement factors
+  kfactor = 1.
+  if 'ttbar' in hname:
+    kfactor = 1.4  * bTagImprove_2b # NLO / LO
+  if '2b2j' in hname:
+    kfactor = 1.3  * bTagImprove_2b # NLO / LO
+  if '4b' in hname:
+    kfactor = 1.6  * bTagImprove_4b  # NLO / LO
+  if 'signal_hh' in hname:
+    kfactor = 1.45 * bTagImprove_4b # (NNLO+NNLL) / NLO 
   
+  # Impose 4 b-tags as weight 
   if do_BTagWeight:
-    my_weight = 'h1_j1_BTagWeight * h1_j2_BTagWeight * h2_j1_BTagWeight * h2_j2_BTagWeight'
+    bTagWeight = 'h1_j1_BTagWeight * h1_j2_BTagWeight * h2_j1_BTagWeight * h2_j2_BTagWeight'
   else:
-    my_weight = 1.
+    bTagWeight = 1.
+
+  # Construct weight string
+  my_weight = '{0} * {1}'.format(bTagWeight, kfactor)
 
   cuts = '( ({0}) * (1000 * {1} * {2} * {3}) ) / {4}'.format( unweighted_cuts, xsec, lumi, my_weight, N_raw ) # Factor of 1000 to convert xsec from ifb to ipb
 
@@ -338,32 +368,42 @@ def compute_chiSq( f_out, signal, lumi, var, unweighted_cuts, N_bkg, N_sig_nom )
   N_sig_raw = nRaw 
   print('Signal {0} yield: {1:.3g}, raw: {2}'.format(signal, N_sig, N_sig_raw))
 
-  # ------------------------------------------------------
-  # Calculate purity S / B and significance S / sqrt(B)
-  # ------------------------------------------------------
-  SoverB            = N_sig / N_bkg
-  SoverSqrtB        = N_sig / math.sqrt( N_bkg )
-  SoverSqrtBSyst1pc = N_sig / math.sqrt( N_bkg + (0.01 * N_bkg ) ** 2 )
-  SoverSqrtBSyst5pc = N_sig / math.sqrt( N_bkg + (0.05 * N_bkg ) ** 2 )
-  
-  # ------------------------------------------------------
-  # Calculate the chi squares
-  # ------------------------------------------------------
-  chiSq          = ( N_sig - N_sig_nom ) ** 2 / ( N_bkg )
-  chiSqSyst1pc   = ( N_sig - N_sig_nom ) ** 2 / ( N_bkg + (0.01 * N_bkg ) ** 2 )
-  chiSqSyst0p5pc = ( N_sig - N_sig_nom ) ** 2 / ( N_bkg + (0.005 * N_bkg ) ** 2 )
-  
-  # ------------------------------------------------------
-  # Calculate acceptance
-  # ------------------------------------------------------
-  acceptance = N_sig / ( xsec * lumi * 1000.)
+  SoverB = 0.
+  SoverSqrtB = 0.
+  SoverSqrtBSyst1pc   = 0.
+  SoverSqrtBSyst0p3pc = 0.
+  chiSq = 0.
+  chiSqSyst1pc = 0.
+  chiSqSyst0p3pc = 0.
+  acceptance = 0.
+
+  if N_bkg > 0.:
+    # ------------------------------------------------------
+    # Calculate purity S / B and significance S / sqrt(B)
+    # ------------------------------------------------------
+    SoverB              = N_sig / N_bkg
+    SoverSqrtB          = N_sig / math.sqrt( N_bkg )
+    SoverSqrtBSyst1pc   = N_sig / math.sqrt( N_bkg + (0.01 * N_bkg ) ** 2 )
+    SoverSqrtBSyst0p3pc = N_sig / math.sqrt( N_bkg + (0.003 * N_bkg ) ** 2 )
+    
+    # ------------------------------------------------------
+    # Calculate the chi squares
+    # ------------------------------------------------------
+    chiSq          = ( N_sig - N_sig_nom ) ** 2 / ( N_bkg )
+    chiSqSyst1pc   = ( N_sig - N_sig_nom ) ** 2 / ( N_bkg + (0.01 * N_bkg ) ** 2 )
+    chiSqSyst0p3pc = ( N_sig - N_sig_nom ) ** 2 / ( N_bkg + (0.003 * N_bkg ) ** 2 )
+    
+    # ------------------------------------------------------
+    # Calculate acceptance
+    # ------------------------------------------------------
+    acceptance = N_sig / ( xsec * lumi * 1000.)
 
   # ------------------------------------------------------
   # Construct string of values to output
   # ------------------------------------------------------
-  out_str  = '{0},{1},{2:.4g},{3:.4g},{4:.4g},'.format( TopYuk, SlfCoup,      N_bkg,             N_sig, N_sig_raw )
-  out_str += '{0:.4g},{1:.4g},{2:.4g},{3:.4g},'.format( SoverB, SoverSqrtB,   SoverSqrtBSyst1pc, SoverSqrtBSyst5pc  )
-  out_str += '{0:.4g},{1:.4g},{2:.4g},{3:.4g},{4}'.format( chiSq,  chiSqSyst1pc, chiSqSyst0p5pc, acceptance, xsec )
+  out_str  = '{0},{1},{2:.4g},{3:.4g},{4:.4g},'.format( TopYuk, SlfCoup,         N_bkg,             N_sig, N_sig_raw )
+  out_str += '{0:.4g},{1:.4g},{2:.4g},{3:.4g},'.format( SoverB, SoverSqrtB,      SoverSqrtBSyst1pc, SoverSqrtBSyst0p3pc  )
+  out_str += '{0:.4g},{1:.4g},{2:.4g},{3:.4g},{4}'.format( chiSq,  chiSqSyst1pc, chiSqSyst0p3pc, acceptance, xsec )
   out_str += '\n'
 
   return out_str

--- a/analysis/plotting/plot.py
+++ b/analysis/plotting/plot.py
@@ -57,6 +57,13 @@ show_legend_slices = False
 # Impose 4 b-tags as weight rather than cutting away events 
 # (TODO: do 2 or 3-tag as options)
 do_BTagWeight = True
+
+# b-tagging improvement factor for 4 b-quarks (hh4b signal, 4b bkg) 
+bTagImprove_4b = 1.36
+
+# 2 b-quarks (2b2j, ttbar bkg)
+bTagImprove_2b = 1.17
+
 #
 #--------------------------------------------------
 
@@ -102,66 +109,84 @@ def main():
             'nnscore_SlfCoup_7.0_sig',
             'nnscore_SlfCoup_10.0_sig',
             'nnscore_SlfCoup_20.0_sig']
-
-  l_cut_sels = ['resolved', 'intermediate' ,'boosted'] 
-  l_cut_sels = ['resolved-commonSR', 'intermediate-commonSR' ,'boosted-commonSR'] 
-  l_cut_sels = ['resolved-preselection', 'intermediate-preselection' ,'boosted-preselection'] 
   
   l_vars     = ['m_hh']
+  
   l_cut_sels = [
-          'resolved-finalSRNNlam_m20', 
-          'intermediate-finalSRNNlam_m20',    
-          'boosted-finalSRNNlam_m20', 
-          'resolved-finalSRNNlam_m10', 
-          'intermediate-finalSRNNlam_m10',    
-          'boosted-finalSRNNlam_m10',
-          'resolved-finalSRNNlam_m7', 
-          'intermediate-finalSRNNlam_m7',    
-          'boosted-finalSRNNlam_m7',
-          'resolved-finalSRNNlam_m5', 
-          'intermediate-finalSRNNlam_m5',    
-          'boosted-finalSRNNlam_m5', 
-          'resolved-finalSRNNlam_m2', 
-          'intermediate-finalSRNNlam_m2',    
-          'boosted-finalSRNNlam_m2', 
-          'resolved-finalSRNNlam_m1', 
-          'intermediate-finalSRNNlam_m1',    
-          'boosted-finalSRNNlam_m1',
-          'resolved-finalSRNNlam_m0p5', 
-          'intermediate-finalSRNNlam_m0p5',    
-          'boosted-finalSRNNlam_m0p5', 
-          'resolved-finalSRNNlam0p5', 
-          'intermediate-finalSRNNlam0p5',    
-          'boosted-finalSRNNlam0p5', 
-          'resolved-finalSRNN', 
-          'intermediate-finalSRNN',    
-          'boosted-finalSRNN',
-          'resolved-finalSRNNlam2', 
-          'intermediate-finalSRNNlam2',    
-          'boosted-finalSRNNlam2',
-          'resolved-finalSRNNlam3', 
-          'intermediate-finalSRNNlam3',    
-          'boosted-finalSRNNlam3', 
-          'resolved-finalSRNNlam5', 
-          'intermediate-finalSRNNlam5',    
-          'boosted-finalSRNNlam5', 
-          'resolved-finalSRNNlam7', 
-          'intermediate-finalSRNNlam7',    
-          'boosted-finalSRNNlam7', 
-          'resolved-finalSRNNlam10', 
-          'intermediate-finalSRNNlam10',    
-          'boosted-finalSRNNlam10', 
-          'resolved-finalSRNNlam20', 
-          'intermediate-finalSRNNlam20',    
-          'boosted-finalSRNNlam20'
+                # Inclusive analyses (no multibin)
+                'SR-res',
+                'SR-int',
+                'SR-bst',
+                
+                'SRNN-res',
+                'SRNN-int',
+                'SRNN-bst',
+
+                # Multibin baseline (no DNN)
+                'SR-res-200mHH250',
+                'SR-res-250mHH300',
+                'SR-res-300mHH350',
+                'SR-res-350mHH400',
+                'SR-res-400mHH500',
+                'SR-res-500mHH',
+                'SR-int-200mHH400',
+                'SR-int-400mHH600',
+                'SR-int-600mHH',
+                'SR-bst-500mHH700',
+                'SR-bst-700mHH900',
+                'SR-bst-900mHH',
+
+                # Multibin baseline with DNN cut trained on k(lambda) = 1
+                'SRNN-res-200mHH250-lam1',
+                'SRNN-res-250mHH300-lam1',
+                'SRNN-res-300mHH350-lam1',
+                'SRNN-res-350mHH400-lam1',
+                'SRNN-res-400mHH500-lam1',
+                'SRNN-res-500mHH-lam1',
+                'SRNN-int-200mHH400-lam1',
+                'SRNN-int-400mHH600-lam1',
+                'SRNN-int-600mHH-lam1',
+                'SRNN-bst-500mHH700-lam1',
+                'SRNN-bst-700mHH900-lam1',
+                'SRNN-bst-900mHH-lam1',
+
+                # Multibin baseline with DNN cut trained on k(lambda) = 5
+                'SRNN-res-200mHH250-lam5',
+                'SRNN-res-250mHH300-lam5',
+                'SRNN-res-300mHH350-lam5',
+                'SRNN-res-350mHH400-lam5',
+                'SRNN-res-400mHH500-lam5',
+                'SRNN-res-500mHH-lam5',
+                'SRNN-int-200mHH400-lam5',
+                'SRNN-int-400mHH600-lam5',
+                'SRNN-int-600mHH-lam5',
+                'SRNN-bst-500mHH700-lam5',
+                'SRNN-bst-700mHH900-lam5',
+                'SRNN-bst-900mHH-lam5',
+
+                # Multibin baseline with DNN cut trained on k(lambda) = 10
+                'SRNN-res-200mHH250-lam10',
+                'SRNN-res-250mHH300-lam10',
+                'SRNN-res-300mHH350-lam10',
+                'SRNN-res-350mHH400-lam10',
+                'SRNN-res-400mHH500-lam10',
+                'SRNN-res-500mHH-lam10',
+                'SRNN-int-200mHH400-lam10',
+                'SRNN-int-400mHH600-lam10',
+                'SRNN-int-600mHH-lam10',
+                'SRNN-bst-500mHH700-lam10',
+                'SRNN-bst-700mHH900-lam10',
+                'SRNN-bst-900mHH-lam10'
+               ]  
+  
+  l_vars     = ['m_hh', 'h1_Pt', 'h2_Pt', 'pT_hh']
+  
+  l_vars     = ['nnscore_SlfCoup_1.0_sig']
+  l_cut_sels = [
+                'SR-res',
+                'SR-int',
+                'SR-bst',
   ]
-  
-  l_cut_sels = ['resolved-finalSR', 'intermediate-finalSR' ,'boosted-finalSR',
-                'resolved-finalSRNN', 'intermediate-finalSRNN','boosted-finalSRNN',
-                'resolved-finalSRNNlam10', 'intermediate-finalSRNNlam10','boosted-finalSRNNlam10',
-               ] 
-  
-  ###
 
   lumi    =  3000.0 #24.3 
   yield_var = "m_hh" # Will plot multiple variables but only want to save yield file for a single variable
@@ -516,17 +541,34 @@ def tree_get_th1f(f, hname, var, sig_reg, unweighted_cuts='', Nbins=100, xmin=0,
  
   h_AfterCut.Sumw2()
   
+  # Normalising number of raw events
   N_raw = f.Get('loose_cutflow').GetBinContent(1)
 
+  # Obtain cross-sections
   d_xsecs = configure_xsecs()
   xsec = d_xsecs[hname]
-  
-  # Impose 4 b-tags as weight (TODO: do 2 or 3-tag as options)
-  if do_BTagWeight:
-    my_weight = 'h1_j1_BTagWeight * h1_j2_BTagWeight * h2_j1_BTagWeight * h2_j2_BTagWeight'
-  else:
-    my_weight = 1.
 
+  # Hard-coded k-factors and b-tagging improvement factors
+  kfactor = 1.
+  if 'ttbar' in hname:
+    kfactor = 1.4  * bTagImprove_2b # NLO / LO
+  if '2b2j' in hname:
+    kfactor = 1.3  * bTagImprove_2b # NLO / LO
+  if '4b' in hname:
+    kfactor = 1.6  * bTagImprove_4b  # NLO / LO
+  if 'signal_hh' in hname:
+    kfactor = 1.45 * bTagImprove_4b # (NNLO+NNLL) / NLO
+  
+  # Impose 4 b-tags as weight 
+  if do_BTagWeight:
+    bTagWeight = 'h1_j1_BTagWeight * h1_j2_BTagWeight * h2_j1_BTagWeight * h2_j2_BTagWeight'
+  else:
+    bTagWeight = 1.
+
+  # Construct weight string
+  my_weight = '{0} * {1}'.format(bTagWeight, kfactor)
+
+  # Construct final TCut string
   cuts = '( ({0}) * (1000 * {1} * {2} * {3}) ) / {4}'.format( unweighted_cuts, xsec, lumifb, my_weight, N_raw ) # Factor of 1000 to convert xsec from ifb to ipb
   
   print('---------------------------------')
@@ -700,16 +742,16 @@ def add_text_to_plot(analysis, sig_reg, cut_sel, lumi, l_cuts, annotate_text, pr
   myText(0.20, 0.87, '#sqrt{s}' + ' = {0}, {1:.0f}'.format(ENERGY_status, lumi) + ' fb^{#minus1}', text_size, kBlack)
   
   analysis = analysis.title()
-  cut_name = cut_sel.split('-')
-  cut_txt = cut_name[0].capitalize() + ' ' + cut_name[1] 
+  if 'res' in cut_sel:
+    cut_txt = cut_sel.replace('-res', ' Resolved')
+  if 'int' in cut_sel:
+    cut_txt = cut_sel.replace('-int', ' Intermediate')
+  if 'bst' in cut_sel or 'boosted' in cut_sel:
+    cut_txt = cut_sel.replace('-bst', ' Boosted')
+
+  print(cut_txt) 
   if 'preselection' in sig_reg:
     myText(0.20, 0.82, cut_txt, text_size, kBlack) 
-  if 'signal' in sig_reg:
-    myText(0.20, 0.82, "SR "+analysis+" "+cut_sel, text_size, kBlack) 
-  if 'control' in sig_reg:
-    myText(0.20, 0.80, "CR "+analysis+" "+cut_sel, text_size, kBlack) 
-  if 'sideband' in sig_reg:
-    myText(0.20, 0.80, "SB "+analysis+" "+cut_sel, text_size, kBlack) 
   
   # Additional annotations
   if not annotate_text == '':

--- a/analysis/plotting/samples.py
+++ b/analysis/plotting/samples.py
@@ -89,7 +89,8 @@ def get_samples_to_plot(analysis = ''):
                  'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_5.0', 
                  #'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_10.0', 
                  #'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m5.0', 
-                 #'loose_noGenFilt_signal_hh_TopYuk_1.1_SlfCoup_1.0', 
+                 #'loose_noGenFilt_signal_hh_TopYuk_1.2_SlfCoup_1.0', 
+                 #'loose_noGenFilt_signal_hh_TopYuk_0.8_SlfCoup_1.0', 
     ]
 
 

--- a/analysis/plotting/variables.py
+++ b/analysis/plotting/variables.py
@@ -171,15 +171,15 @@ def configure_vars(cut_sel):
   } # end of d_vars = {} dictionary
 
   # analysis specific binning and ranges 
-  if 'resolved' in cut_sel:
+  if 'res' in cut_sel:
     d_vars['m_hh']   = {'tlatex':'#it{m}_{hh}'               ,'units':'GeV','hXNbins':50,'hXmin':100,'hXmax':1100}
     d_vars['h1_Pt']  = {'tlatex':'#it{p}_{T}(h_{1}^{cand})'  ,'units':'GeV','hXNbins':25,'hXmin':0, 'hXmax' :500}
     d_vars['h2_Pt']  = {'tlatex':'#it{p}_{T}(h_{2}^{cand})'  ,'units':'GeV','hXNbins':25,'hXmin':0, 'hXmax' :500}
-  if 'intermediate' in cut_sel:
+  if 'int' in cut_sel:
     d_vars['m_hh']    = {'tlatex':'#it{m}_{hh}'              ,'units':'GeV','hXNbins':40,'hXmin':200,'hXmax':1800}
     d_vars['h1_Pt']   = {'tlatex':'#it{p}_{T}(h_{1}^{cand})' ,'units':'GeV','hXNbins':20,'hXmin':200,'hXmax':1000}
     d_vars['h2_Pt']   = {'tlatex':'#it{p}_{T}(h_{2}^{cand})' ,'units':'GeV','hXNbins':20,'hXmin':0,  'hXmax':800}
-  if 'boosted' in cut_sel:
+  if 'bst' in cut_sel or 'boosted' in cut_sel:
     d_vars['m_hh']    = {'tlatex':'#it{m}_{hh}'              ,'units':'GeV','hXNbins':50,'hXmin':200,'hXmax':2700}
     d_vars['h1_Pt']   = {'tlatex':'#it{p}_{T}(h_{1}^{cand})' ,'units':'GeV','hXNbins':30,'hXmin':200,'hXmax':1700}
     d_vars['h2_Pt']   = {'tlatex':'#it{p}_{T}(h_{2}^{cand})' ,'units':'GeV','hXNbins':30,'hXmin':200,'hXmax':1700}


### PR DESCRIPTION
- ITk b-tag scale factor: (hh signal, 4b bkg) use 1.36, (ttbar, 2b2j) use 1.17.
- Global k-factors (NNLO+NNLL)/NLO = 1.45 applied to all signals.
- NLO k-factors for dominant bkgs: ttbar = 1.4, 4b =  1.6, 2b2j: 1.3.
- 12-bin multi-bin SR fit: 6 bins resolved, 3 bins intermediate, 3 bins boosted.
- 1% → 0.3% background systematic uncertainties.
- Only 1 cut on DNN score > 0.85 (removed cuts on QCD and top scores).
- 1D chi-sq has explicit comparison with ATLAS HL-LHC PUB projections.
