### PR TITLE
Aesthetic improvements to summary plots 17 Feb draft

### DIFF
--- a/analysis/plotting/chiSq_to_1Dlimit.py
+++ b/analysis/plotting/chiSq_to_1Dlimit.py
@@ -143,6 +143,9 @@ SQRTS_LUMI = '#sqrt{s} = 14 TeV, 3000 fb^{#minus1}'
 # Switch to true to zoom in on x-axis 
 zoom_in = True
 
+# Overlay ATLAS HL-LHC projections
+show_HLLHC_atlas_proj = False
+
 #____________________________________________________________________________
 def main():
 
@@ -208,8 +211,10 @@ def main():
                            'SRNN_res_multibin_lamM5_combined'] 
   '''
 
-  # acceptance plots, set zoom_in to False
+
   '''
+  #----------------------------------------------------------
+  # acceptance plots, set zoom_in to False
   l_zCols = ['acceptance']
 
   IsLogY = True
@@ -218,10 +223,17 @@ def main():
   d_SRsets['baseline-no-mhh-binning']   = ['SR-res', 
                                            'SR-int', 
                                            'SR-bst']
+  d_SRsets['DNN-lam1-no-mhh-binning']   = ['SRNN-res-lam1', 
+                                           'SRNN-int-lam1', 
+                                           'SRNN-bst-lam1']
+  d_SRsets['DNN-lam5-no-mhh-binning']   = ['SRNN-res-lam5', 
+                                           'SRNN-int-lam5', 
+                                           'SRNN-bst-lam5']
+  #----------------------------------------------------------
   '''
 
   d_axis_tlatex = {
-    'acceptance'         : 'A #times \epsilon (S / #sigma #times L) [%]',
+    'acceptance'         : 'A #times #varepsilon',
     'xsec'               : 'xsec [pb]',
     'N_sig'              : 'Signal yield',
     'N_sig_raw'          : 'Raw signal yield',
@@ -304,9 +316,9 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
       xl1, yl1 = 0.45, 0.5
   elif extra_space > 0.25:
     if zoom_in: 
-      xl1, yl1 = 0.43, 0.38
+      xl1, yl1 = 0.42, 0.37
     else:
-      xl1, yl1 = 0.43, 0.6
+      xl1, yl1 = 0.42, 0.6
   elif extra_space > 0.:
     if zoom_in: 
       xl1, yl1 = 0.35, 0.54
@@ -352,7 +364,8 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
     lim_ATL_HLLHC_left.SetFillColorAlpha(kGray+1,  0.2)
     lim_ATL_HLLHC_right.SetFillColorAlpha(kGray+1, 0.2)
   
-    leg.AddEntry(lim_ATL_HLLHC_left, 'ATLAS 3 ab^{#minus1}', 'f')
+    if show_HLLHC_atlas_proj:
+      leg.AddEntry(lim_ATL_HLLHC_left, 'ATLAS 3 ab^{#minus1}', 'f')
   
   #------------------------------------------------------
   # Get and organise data
@@ -398,7 +411,11 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
     tg.SetMarkerColor(d_cut_sel_colour[cut_sel])
     tg.SetMarkerSize(width)
     tg.SetLineColor(d_cut_sel_colour[cut_sel])
-    tg.SetLineWidth(width)
+    # For combined contour reduce width so we can see it
+    if 'all' in cut_sel:
+      tg.SetLineWidth(width-2)
+    else:
+      tg.SetLineWidth(width)
     tg.SetTitle('')
 
     for i, (x, y) in enumerate( zip( l_SlfCoup_or_TopYuk, l_chiSq) ):
@@ -420,10 +437,13 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
       cut_txt = 'Res + Int '
     elif 'res' in cut_sel:
       cut_txt = 'Resolved '
+      if 'chiSqSystMix' in zCol: cut_txt += '(0.3%)'
     elif 'int' in cut_sel:
       cut_txt = 'Intermediate '
+      if 'chiSqSystMix' in zCol: cut_txt += '(1%)'
     elif 'bst' in cut_sel or 'boosted' in cut_sel:
       cut_txt = 'Boosted '
+      if 'chiSqSystMix' in zCol: cut_txt += '(5%)'
     elif 'all' in cut_sel:
       cut_txt = 'Combined '
     else:
@@ -444,11 +464,11 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
   
     if 'NN' in cut_sel: 
       if 'lam10' in cut_sel:
-        myText(0.08, 0.07, 'DNN trained on #kappa(#lambda_{hhh}) = 10', 0.035, kGray+2, 0, True)
+        myText(0.08, 0.07, 'DNN trained on #kappa_{#lambda} = 10', 0.035, kGray+2, 0, True)
       elif 'lam5' in cut_sel:
-        myText(0.08, 0.07, 'DNN trained on #kappa(#lambda_{hhh}) = 5', 0.035, kGray+2, 0, True)
+        myText(0.08, 0.07, 'DNN trained on #kappa_{#lambda} = 5', 0.035, kGray+2, 0, True)
       else:
-        myText(0.08, 0.07, 'DNN trained on #kappa(#lambda_{hhh}) = 1', 0.035, kGray+2, 0, True)
+        myText(0.08, 0.07, 'DNN trained on #kappa_{#lambda} = 1', 0.035, kGray+2, 0, True)
 
     leg.AddEntry(tg, cut_txt, 'l')
 
@@ -500,17 +520,19 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
     label_y = 0.84
   
   if do_ktop:
-    fixed_coupling = '#kappa(#lambda_{hhh}) = 1'
+    fixed_coupling = '#kappa_{#lambda} = 1'
   else:
-    fixed_coupling = '#kappa(#it{y}_{top}) = 1'
+    fixed_coupling = '#kappa_{#it{t}} = 1'
 
   if do_ktop:
-    xtitle = '#kappa(#it{y}_{top})'
+    xtitle = '#kappa_{#it{t}}'
   else:
-    xtitle = '#kappa(#lambda_{hhh})'
+    xtitle = '#kappa_{#lambda}'
 
   ytitle = d_axis_tlatex[zCol]
 
+  if 'chiSqSystMix' in zCol: 
+      myText(0.45, 0.69, 'Category (systematic #zeta_{b})', 0.038, kBlack, 0, True)
   if 'chiSqSyst1pc' in zCol:
     syst_txt = ', 1% systematics'
   elif 'chiSqSyst0p3pc' in zCol:
@@ -583,8 +605,9 @@ def make_plot( d_in_data, out_file, l_cut_sels, do_ktop, zCol, d_axis_tlatex, Is
   customise_axes(d_tgraphs[l_cut_sels[0]], xtitle, ytitle, 2.8, IsLogY, doktop = do_ktop, zCol = zCol)
   
   if 'acceptance' not in zCol:
-    lim_ATL_HLLHC_left.Draw('same')
-    lim_ATL_HLLHC_right.Draw('same')
+    if show_HLLHC_atlas_proj:
+      lim_ATL_HLLHC_left.Draw('same')
+      lim_ATL_HLLHC_right.Draw('same')
  
 
   #==========================================================
@@ -640,9 +663,9 @@ def customise_axes(hist, xtitle, ytitle, scaleFactor=1.1, IsLogY=False, enlargeY
   #xax.SetRangeUser(-20,20)
 
   if doktop: 
-    if zoom_in:
-      xax.SetRangeUser(-0.2,1.4) 
-    else:
+    #if zoom_in:
+    #  xax.SetRangeUser(-0.2,1.4) 
+    #else:
       xax.SetRangeUser(0.5,1.5) 
   else:
     if zoom_in:
@@ -691,8 +714,8 @@ def customise_axes(hist, xtitle, ytitle, scaleFactor=1.1, IsLogY=False, enlargeY
       hist.SetMaximum(5)
     hist.SetMinimum(0.0)
     #hist.SetMaximum(ymax*scaleFactor) 
-  if 'A #times \epsilon' in ytitle:
-    hist.SetMinimum(5E-3)
+  if 'A #times #varepsilon' in ytitle:
+    hist.SetMinimum(1E-3)
     hist.SetMaximum(10.0) 
     yax.SetNdivisions(205)
 

--- a/analysis/plotting/contours_to_summary.py
+++ b/analysis/plotting/contours_to_summary.py
@@ -71,7 +71,7 @@ def main():
     'SRNN_bst_multibin_lam1_combined'  : 'Boosted',
     'SRNN_all_multibin_lam1_combined'  : 'Combined',
     'SRNN_all_multibin_lam5_combined'  : 'Combined #kappa_{#lambda} = 5',
-    'SRNN_all_multibin_lam7_combined'  : 'Combined #kappa_{#lambda} = 7',
+    'SRNN_all_multibin_lam7_combined' : 'Combined #kappa_{#lambda} = 7',
   }
 
   xCol, yCol = 'x', 'y'
@@ -129,29 +129,16 @@ def mk_plot(l_contours, d_tg, save_name, d_tlatex):
   myLightOrange   = TColor.GetColor('#fec49f')
   myMediumOrange  = TColor.GetColor('#fe9929')
   myDarkOrange    = TColor.GetColor('#ec7014')
-  myDarkerOrange  = TColor.GetColor('#cc4c02')
-  
-  myDarkRed       = TColor.GetColor('#a50f15')
-
-  # Pinks
-  myLightPink     = TColor.GetColor('#fde0dd')
-  myMediumPink    = TColor.GetColor('#fcc5c0')
-  myDarkPink      = TColor.GetColor('#dd3497')
-
-  # Purples
-  myLightPurple   = TColor.GetColor('#dadaeb')
-  myMediumPurple  = TColor.GetColor('#9e9ac8')
-  myDarkPurple    = TColor.GetColor('#6a51a3')
   
   l_colours = [
-    myLightBlue,
-    myMediumBlue,
     myDarkBlue,
-    myDarkPurple,
-    myLightOrange,
-    myMediumOrange,
-    myDarkRed,
-    myDarkPink
+    myMediumBlue,
+    myLightBlue,
+    myDarkOrange,
+    myDarkBlue,
+    myMediumBlue,
+    myLightBlue,
+    myDarkOrange,
     ]
  
   # Dummy graph as first one 
@@ -163,11 +150,11 @@ def mk_plot(l_contours, d_tg, save_name, d_tlatex):
   
   tg_dummy.Draw('AL')
   tg_dummy.SetTitle('')
-  tg_dummy.GetXaxis().SetRangeUser(-19,18)
+  tg_dummy.GetXaxis().SetRangeUser(-19,17)
   tg_dummy.GetYaxis().SetRangeUser(0.6,1.4)
   
   xtitle = '#kappa_{#lambda}'
-  ytitle = '#kappa_{t}'
+  ytitle = '#kappa_{#it{t}}'
   customise_axes(tg_dummy, xtitle, ytitle)
 
   # Marker for SM
@@ -182,8 +169,8 @@ def mk_plot(l_contours, d_tg, save_name, d_tlatex):
   #-------------------------------------------------
   xl1=0.26
   #yl1=0.62
-  yl1=0.45
-  xl2=xl1+0.15
+  yl1=0.52
+  xl2=xl1+0.18
   yl2=yl1+0.17
   # Blues baseline
   leg = TLegend(xl1,yl1,xl2,yl2)
@@ -216,14 +203,14 @@ def mk_plot(l_contours, d_tg, save_name, d_tlatex):
       tg.SetLineStyle(2)
       leg.AddEntry(tg, d_tlatex[contour], 'L')
 
-    if 'resolved' in contour:
-      tg.SetLineWidth(4)
-    if 'intermediate' in contour:
-      tg.SetLineWidth(3)
-    if 'boosted' in contour:
-      tg.SetLineWidth(2)
-    if 'combined' in contour:
+    if 'res' in contour:
       tg.SetLineWidth(5)
+    if 'int' in contour:
+      tg.SetLineWidth(5)
+    if 'bst' in contour:
+      tg.SetLineWidth(5)
+    if 'all' in contour:
+      tg.SetLineWidth(3)
 
     # Add some text to bookkeep which DNN training we're using
     if 'SRNN' in contour:
@@ -254,8 +241,8 @@ def mk_plot(l_contours, d_tg, save_name, d_tlatex):
   # Add text to plot interior
   #myText(0.20, 0.80, 'DNN', 0.035, kBlack, 0, True)
   #myText(0.27, 0.80, 'Baseline', 0.035, kBlack, 0, True)
-  myText(0.20, 0.63, 'DNN', 0.035, kBlack, 0, True)
-  myText(0.27, 0.63, 'Baseline', 0.035, kBlack, 0, True)
+  myText(0.20, 0.70, 'DNN', 0.035, kBlack, 0, True)
+  myText(0.27, 0.70, 'Baseline', 0.035, kBlack, 0, True)
   myText(0.60, 0.55,  'SM', 0.04, kGray+2, 0, True)
   
   gPad.RedrawAxis()

--- a/analysis/plotting/plot_signal_only.py
+++ b/analysis/plotting/plot_signal_only.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python
+'''
+plot_signalOnly.py is the main script to do the plotting
+This reads the ntuples produced by SusySkimHiggsino
+Makes plots of data vs MC in various variables
+Configure various aspects in
+  - cuts.py
+  - samples.py
+  - variables.py
+One specifies the samples to be plotted at the top of calc_selections() function
+'''
+# So Root ignores command line inputs so we can use argparse
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gROOT.SetBatch(1)
+from ROOT import *
+
+import os, sys, time, argparse, time
+from math import sqrt
+from random import gauss
+from array import array
+
+from samples import *
+from cuts import *
+from variables import *
+
+SIGPATH = '/data/atlas/atlasdata/DiHiggsPheno/ntuples/150719/merged_nn_score_ntuples'
+
+doBTagWeight = True
+
+normalise_unity = True
+
+# text size as percentage
+text_size = 0.05
+
+#____________________________________________________________________________
+def main():
+  
+  t0 = time.time()
+  
+  #================================================
+  # default values
+  sig_reg = 'SR-preselect'
+  var     = 'Jet[0].PT'
+
+  lumi    = 1.0 # [1/fb]
+  
+  #lumi    = 80.0 # [1/fb]
+  ttbarSamp='ttbar'
+  unblind = False
+  cutArrow = False
+  IsLogY = False
+
+  # check user has inputted variables or not
+  parser = argparse.ArgumentParser(description='Analyse background/signal TTrees and make plots.')
+  parser.add_argument('-v', '--variable',  type=str, nargs='?', help='String name for the variable (as appearing in the TTree) to make N-1 in.', default=var)
+  parser.add_argument('-s', '--sigReg',    type=str, nargs='?', help='String name of selection (signal/control) region to perform N-1 selection.', default=sig_reg)
+  parser.add_argument('-n', '--noLogY',  action='store_true', help='Do not draw log Y axis.')
+ 
+  args = parser.parse_args()
+  if args.variable:
+    var      = args.variable
+  if args.sigReg:
+    sig_reg = args.sigReg
+  if args.noLogY:
+    IsLogY = False
+
+  print( '=========================================' )
+  print( 'Plotting variable: {0}'.format(var) )
+  print( 'Selection region: {0}'.format(sig_reg) )
+  print( 'Normalising luminosity: {0}'.format(lumi) )
+  print( '=========================================\n' )
+  
+  #================================================
+  # make (relative) save directory if needed 
+  savedir = 'figs/2019mar18'
+  mkdir(savedir)
+
+  l_SRs = [
+    'all-preselection'
+    ]
+  l_vars = [
+  # 'n_large_jets',
+   'm_hh'
+  ]
+  
+  for var in l_vars:
+    for sig_reg in l_SRs:
+      save_var = var
+      # convert maths characters are legit file names
+      if '/' in var:
+        save_var = var.replace('/', 'Over', 1)
+      if '(' in var:
+        save_var = save_var.replace('(', '', 1)
+      if ')' in var:
+        save_var = save_var.replace(')', '', 1)
+      if IsLogY:
+        save_name = savedir + '/hist1d_{0}_{1}'.format(save_var, sig_reg)
+      if not IsLogY:
+        save_name = savedir + '/hist1d_{0}_{1}_noLogY'.format(save_var, sig_reg)
+
+      add_cut = 'm_hh > 0'
+      annotate_text = ''
+      calc_selections(var, add_cut, lumi, save_name, sig_reg, annotate_text, ttbarSamp, unblind, cutArrow, IsLogY)
+
+  tfinish = time.time()
+  telapse = tfinish - t0
+  print( '{0:.3f}s'.format(telapse))
+
+#____________________________________________________________________________
+def calc_selections(var, add_cuts, lumi, save_name, sig_reg, annotate_text='', ttbarSamp='ttbar', unblind=False, cutArrow=False, IsLogY=True):
+  '''
+  Extract trees given a relevant variable
+  '''
+  #==========================================================
+  # Prepare information and objects for analysis and plots
+  #==========================================================
+
+  l_samp = [
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m5.0',
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m2.0',
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m1.0',
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_1.0',
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_2.0',
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_3.0',
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_5.0',
+    #'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_10.0',
+  ]
+
+  # obtain cut to apply (string)
+  normCutsAfter, l_cuts = configure_cuts(sig_reg) 
+  
+  # get dictionary defining sample properties
+  d_samp = configure_samples()
+  
+  # get dictionary of histogram configurations
+  d_vars = configure_vars()
+  # obtain the number of bins with their xmin and xmax
+  hNbins = d_vars[var]['hXNbins']
+  hXmin  = d_vars[var]['hXmin']
+  hXmax  = d_vars[var]['hXmax']
+
+  variable_bin = False
+  hXarray = []
+  if hNbins == 'var':
+    variable_bin = True
+    hXarray = d_vars[var]['binsLowE']  
+    hNbins = len(hXarray) - 1
+
+  # declare stacked background  
+  hs = THStack('','')
+  hs_intgl_low = THStack('','') # lower cut integral (for significance cut)
+  hs_intgl_upp = THStack('','') # upper cut integral (for significance cut)
+ 
+  # initialise objects to fill in loop 
+  d_files = {}
+  d_hists = {}
+  d_hsig  = {}
+  d_yield = {}
+  d_nRaw = {}
+  d_yieldErr = {}
+  nTotBkg = 0 # yield of background
+  nRawBkg = 0 # yield of background
+  nVarBkg = 0 # variance of background
+ 
+  l_bkg = []
+  l_sig = []
+  
+  h_dat = 0
+  N_dat = 0
+
+  #==========================================================
+  # loop through samples, fill histograms
+  #==========================================================
+  myLightBlue     = TColor.GetColor('#9ecae1')
+  myMediumBlue    = TColor.GetColor('#0868ac')
+  myDarkBlue      = TColor.GetColor('#08306b')
+  
+  myMediumOrange  = TColor.GetColor('#feb24c')
+  myDarkOrange    = TColor.GetColor('#ec7014')
+  myDarkerOrange  = TColor.GetColor('#cc4c02')
+  
+  l_styles = [1, 1, 1, 2, 1, 1, 1]
+  l_colors = [myDarkBlue, myMediumBlue, myLightBlue, kGray+1, myMediumOrange, myDarkOrange, myDarkerOrange]
+  Nsignal_count = 0
+  for count, samp in enumerate(l_samp):
+    print('Processing sample: {0}'.format(samp))
+    full_path = SIGPATH + '/' + samp + '.root'
+    
+    cutsAfter = normCutsAfter 
+
+    # assign TFile to a dictionary entry
+    d_files[samp] = TFile(full_path)
+
+    weighted_lumi = str(lumi)
+    if doBTagWeight:
+      if '2b' in sig_reg:
+        weighted_lumi = '{0} * h1_j1_BTagWeight * h1_j2_BTagWeight'.format(lumi)
+      if '4b' in sig_reg:
+        weighted_lumi = '{0} * h1_j1_BTagWeight * h1_j2_BTagWeight * h2_j1_BTagWeight * h2_j2_BTagWeight'.format(lumi)
+
+    # obtain histogram from file and store to dictionary entry
+    d_hists[samp] = tree_get_th1f( d_files[samp], samp, var, cutsAfter, hNbins, hXmin, hXmax, weighted_lumi, variable_bin, hXarray)
+
+    # ---------------------------------------------------- 
+    # Stacked histogram: construct and format
+    # ---------------------------------------------------- 
+    # extract key outputs of histogram 
+    hist        = d_hists[samp][0]
+    nYield      = d_hists[samp][1]
+    h_intgl_low = d_hists[samp][2]
+    h_intgl_upp = d_hists[samp][3]
+    nYieldErr   = d_hists[samp][4]
+    nRaw        = d_hists[samp][5]
+    
+    # samp : nYield number of events for each sample
+    d_yield[samp]    = nYield
+    d_hsig[samp]     = hist
+    d_nRaw[samp]     = nRaw
+    d_yieldErr[samp] = nYieldErr
+    # add background to stacked histograms
+    format_hist(hist, 3, l_colors[count], l_styles[count], f_color=0)
+    Nsignal_count += 1
+    l_sig.append(samp) 
+  leg = mk_leg(0.72, 0.45, 0.92, 0.85, sig_reg, l_samp, d_samp, nTotBkg, d_hists, d_yield, d_yieldErr, d_nRaw, sampSet_type='bkg', txt_size=0.05)
+   
+  #============================================================
+  # proceed to plot
+  plot_selections(var, d_hsig, leg, save_name, sig_reg, nTotBkg, l_sig, cutsAfter, l_cuts, annotate_text, variable_bin, IsLogY)
+  
+  return nTotBkg
+
+#____________________________________________________________________________
+def plot_selections(var, d_hsig, leg, save_name, sig_reg, nTotBkg, l_sig, cutsAfter, l_cuts, annotate_text, variable_bin, IsLogY=True):
+  '''
+  plots the variable var given input THStack h_bkg, one signal histogram and legend built
+  makes a dat / bkg panel in lower part of figure
+  to-do: should be able to read in a list of signals
+  '''
+  print('Proceeding to plot')
+  
+  # gPad left/right margins
+  gpLeft = 0.14
+  gpRight = 0.05
+  
+  
+  d_vars = configure_vars()
+  
+  #==========================================================
+  # build canvas
+  can  = TCanvas('','',1300,1000)
+  customise_gPad()
+  
+  pad1 = TPad('pad1', '', 0.0, 0.0, 1.0, 1.0)
+  #pad2 = TPad('pad2', '', 0.0, 0.00, 1.0, 0.4)
+  pad1.Draw()
+  pad1.cd()
+  
+  if IsLogY:
+    pad1.SetLogy()
+  customise_gPad(top=0.07, bot=0.22, left=gpLeft, right=gpRight)
+  #customise_gPad(top=0.03, bot=0.20, left=gpLeft, right=gpRight)
+  #=============================================================
+  # draw signal samples
+  print('--------------------------------------')
+  print('Drawing histograms')
+  print(d_hsig)
+  for samp in l_sig:
+    print('Drawing {0}'.format(samp))
+    d_hsig[samp].Draw('hist same') #e2 = error coloured band
+  # clone the total background histogram to draw the line
+  
+  leg.Draw('same')
+  #==========================================================
+  # calculate bin width 
+  hNbins = d_vars[var]['hXNbins']
+  hXmin  = d_vars[var]['hXmin']
+  hXmax  = d_vars[var]['hXmax']
+  if not variable_bin:
+    binWidth = (hXmax - hXmin) / float(hNbins)
+  
+  # label axes of top pad
+  xtitle = ''
+  binUnits = d_vars[var]['units']
+  if variable_bin:
+    ytitle = 'Events / bin'
+  elif 0.1 < binWidth < 1:
+    ytitle = 'Events / {0:.2f} {1}'.format(binWidth, binUnits)
+  elif binWidth <= 0.1:
+    ytitle = 'Events / {0:.2f} {1}'.format(binWidth, binUnits)
+  elif binWidth >= 1:
+    if normalise_unity:
+      #ytitle = 'Fraction of Events / {0:.0f} {1}'.format(binWidth, binUnits)
+      ytitle = 'Fraction of Events'.format(binWidth, binUnits)
+    else:
+      ytitle = 'Events / {0:.0f} {1}'.format(binWidth, binUnits)
+  enlargeYaxis = False
+  #if 'Pass' in sig_reg or 'preselect':
+  if 'Pass' in sig_reg or 'preselect' in sig_reg:
+    enlargeYaxis = False
+   
+  varTeX = 'tlatex'
+  
+  Xunits = d_vars[var]['units']
+  if Xunits == '':
+    #xtitle = '{0}'.format( d_vars[var]['tlatex'])
+    xtitle = '{0}'.format( d_vars[var][varTeX])
+  else:
+    xtitle = '{0} [{1}]'.format( d_vars[var][varTeX], Xunits ) 
+  
+  customise_axes(d_hsig[l_sig[0]], xtitle, ytitle, 1.6, IsLogY, enlargeYaxis)
+  
+  myText(0.19, 0.84, 'pp #rightarrow hh, #kappa_{#it{t}} = 1, #sqrt{s} = 14 TeV', text_size, kBlack) 
+  myText(0.19, 0.77, 'Reconstructed level, preselection', text_size, kBlack) 
+  if doBTagWeight:
+    if '2b' in sig_reg:
+      l_2b = ['h1_j1_BTagWeight',
+              'h1_j2_BTagWeight' ]
+      l_cuts += l_2b
+   
+    if '4b' in sig_reg: 
+      l_4b = ['h1_j1_BTagWeight',
+              'h1_j2_BTagWeight',
+              'h2_j1_BTagWeight',
+              'h2_j2_BTagWeight' ]
+      l_cuts += l_4b
+
+  gPad.RedrawAxis() 
+
+  #==========================================================
+  # save everything
+  can.cd()
+  can.SaveAs(save_name + '.pdf')
+  #can.SaveAs(save_name + '.eps')
+  #can.SaveAs(save_name + '.png')
+  can.Close()
+  
+#_______________________________________________________
+def tree_get_th1f(f, hname, var, cutsAfter='', Nbins=100, xmin=0, xmax=100, lumifb=35, variable_bin=False, hXarray=0):
+  '''
+  from a TTree, project a leaf 'var' and return a TH1F
+  '''
+  print(hname)
+  if variable_bin:
+    h_AfterCut   = TH1D(hname + '_hist', "", Nbins, array('d', hXarray) )
+  else:
+    h_AfterCut   = TH1D(hname + '_hist', "", Nbins, xmin, xmax)
+ 
+  #h_AfterCut.Sumw2()
+ 
+  # MadGraph LO cross-sections in pb
+  d_xsec = {
+    'pp2hh_loop_sm' : 1.60835E-02,
+    'pp2hh_TopYuk_1.0_SlfCoup_1.0' : 1.60835E-02,
+    'pp2hh_TopYuk_1.0_SlfCoup_2.0' : 3.68395E-02,
+    'pp2hh_TopYuk_1.0_SlfCoup_5.0' : 3.68395E-02,
+    'pp2hh_TopYuk_1.0_SlfCoup_m5.0' : 2.58555E-01,
+    'bbh'        : 7.6E-02,
+    'tth'        : 4.35E-01,
+    'zh'         : 7.19E-01,
+    'wh'         : 1.36,
+    'pp2ttbar'   : 597.,
+    'ttbar'      : 597.,
+    'pp2bbbb'    : 8.9e+05,
+    'pp2bbjj'    : 7.2e+06,
+    'pp2jjjj'    : 1.8e+07,
+    '4b_20_to_200'       : 63.2,
+    '4b_200_to_500'      : 2.82,
+    '4b_500_to_1000'     : 4.08E-02,
+    '4b_1000_to_infty'   : 5.50E-04,
+    '2b2j_20_to_200'     : 2.26E+04,
+    '2b2j_200_to_500'    : 1.54E+03,
+    '2b2j_500_to_1000'   : 35.26,
+    '2b2j_1000_to_infty' : 0.706,
+  }
+  
+  lumi     = '({0}) * (10 ** 3)'.format(lumifb) # convert to [pb^{-1}]
+  xsec = 1.
+  #xsec = d_xsec[hname]
+  if 'pp2hh' in hname:
+    my_weight = 1000.
+  else:
+    my_weight = 1.
+  
+  t = f.Get( 'preselection') 
+  Ngen = f.loose_cutflow.GetBinContent(1)
+  print('Ngen: {0}'.format(Ngen))
+   
+  cut_after = '({0}) * ({1}) * ({2}) * ({3}) / ({4})'.format(cutsAfter, xsec, lumi, my_weight, float(Ngen)) 
+  #cut_after = '( ({0}) * ({1}) ) * Event.Weight * {2}'.format(cutsAfter, lumi, my_weight) 
+  # ========================================================= 
+  t.Project( hname + '_hist', var, cut_after )
+  # =========================================================
+  # perform integrals to find 
+  # total yield, one-sided lower and upper cumulative histos
+  nYieldErr = ROOT.Double(0)
+  nYield    = h_AfterCut.IntegralAndError(0, Nbins+1, nYieldErr)
+  nRaw      = h_AfterCut.GetEntries()
+  h_intgl_lower = TH1D(hname + '_intgl_lower', "", Nbins, xmin, xmax)
+  h_intgl_upper = TH1D(hname + '_intgl_upper', "", Nbins, xmin, xmax)
+ 
+  if normalise_unity:
+    h_AfterCut.Scale(1./nYield)
+  
+  print('---------------------------------------------')
+  print('N generated events: {0}'.format(Ngen) )
+  print('N raw events after cuts: {0}'.format(nRaw) )
+  print('Weighted cutstring: {0}'.format(cut_after) )
+  print('---------------------------------------------')
+  
+  for my_bin in range( h_AfterCut.GetXaxis().GetNbins() + 1 ):
+    
+    # get lower edge of bin
+    bin_low = h_AfterCut.GetXaxis().GetBinLowEdge( my_bin )
+    
+    # set the negatively weighted values to 0.
+    bin_val = h_AfterCut.GetBinContent( my_bin )
+    if bin_val < 0:
+      print( 'WARNING: Bin {0} of sample {1} has negative entry, setting central value to 0.'.format(my_bin, hname) )
+      h_AfterCut.SetBinContent(my_bin, 0.)
+    
+    # do one-sided integral either side of bin
+    intgl_lower = h_AfterCut.Integral( 0, my_bin ) 
+    intgl_upper = h_AfterCut.Integral( my_bin, Nbins+1 ) 
+    
+    h_intgl_lower.Fill( bin_low, intgl_lower )
+    h_intgl_upper.Fill( bin_low, intgl_upper )
+  print( 'Sample {0} has integral {1:.3f} +/- {2:.3f} (raw {3})'.format( hname, nYield, nYieldErr, nRaw ) )
+
+  # =========================================================
+  
+  return [h_AfterCut, nYield, h_intgl_lower, h_intgl_upper, nYieldErr, nRaw]
+
+#____________________________________________________________________________
+def format_hist(hist, l_width=2, l_color=kBlue+2, l_style=1, f_color=0, f_style=1001, l_alpha=1.0):
+  
+  # lines
+  hist.SetLineColorAlpha(l_color, l_alpha)
+  hist.SetLineStyle(l_style)
+  hist.SetLineWidth(l_width)
+  
+  # fills
+  hist.SetFillColor(f_color)
+  hist.SetFillStyle(f_style)
+  # markers
+  hist.SetMarkerColor(l_color)
+  hist.SetMarkerSize(1.1)
+  hist.SetMarkerStyle(20)
+
+#____________________________________________________________________________
+def customise_gPad(top=0.03, bot=0.15, left=0.17, right=0.08):
+  gPad.Update()
+  gStyle.SetTitleFontSize(0.0)
+  
+  # gPad margins
+  gPad.SetTopMargin(top)
+  gPad.SetBottomMargin(bot)
+  gPad.SetLeftMargin(left)
+  gPad.SetRightMargin(right)
+  
+  gStyle.SetOptStat(0) # hide usual stats box 
+  
+  gPad.Update()
+  
+#____________________________________________________________________________
+def customise_axes(hist, xtitle, ytitle, scaleFactor=1.1, IsLogY=False, enlargeYaxis=False):
+  # set a universal text size
+  #text_size = 0.055
+  text_size = 55
+  TGaxis.SetMaxDigits(4) 
+  ##################################
+  # X axis
+  xax = hist.GetXaxis()
+  xax.CenterTitle() 
+  
+  # precision 3 Helvetica (specify label size in pixels)
+  xax.SetLabelFont(133)
+  xax.SetTitleFont(133)
+  #xax.SetTitleFont(13) # times
+ 
+  print('xtitle: ' + xtitle) 
+  xax.SetTitle(xtitle)
+  xax.SetTitleSize(text_size*1.2)
+  xax.SetLabelSize(text_size)
+  xax.SetLabelOffset(0.03)
+  xax.SetTitleOffset(1.5)
+  xax.SetTickSize(0.04)
+
+  #xax.SetRangeUser(0,2000) 
+  #xax.SetNdivisions(5) 
+  gPad.SetTickx() 
+  
+  ##################################
+  # Y axis
+  yax = hist.GetYaxis()
+  # precision 3 Helvetica (specify label size in pixels)
+  yax.SetLabelFont(133)
+  yax.SetTitleFont(133)
+  yax.CenterTitle() 
+ 
+  
+  yax.SetTitle(ytitle)
+  yax.SetTitleSize(text_size*1.2)
+  yax.SetTitleOffset(1.0)    
+  
+  yax.SetLabelOffset(0.015)
+  yax.SetLabelSize(text_size - 7)
+ 
+  ymax = hist.GetMaximum()
+  ymin = hist.GetMinimum()
+  
+  # top events panel
+  #if xtitle == '':
+  if 'Events' in ytitle:
+    yax.SetNdivisions(505) 
+    if IsLogY:
+      if enlargeYaxis:
+        ymax = 2 * 10 ** 10
+        ymin = 20
+      else:
+        ymax = 3 * 10 ** 8
+        ymin = 0.05
+        #ymax = 3 * 10 ** 3
+        #ymin = 0.0005
+      hist.SetMaximum(ymax)
+      hist.SetMinimum(ymin)
+    else:
+      if normalise_unity:
+        hist.SetMaximum(ymax*scaleFactor)
+      else:
+        hist.SetMaximum(ymax*scaleFactor)
+      #hist.SetMaximum(100)
+      #hist.SetMaximum(30)
+      #hist.SetMaximum(60)
+      hist.SetMinimum(0.0)
+  # bottom data/pred panel 
+  elif 'Significance' in ytitle or 'sqrt' in ytitle:
+    hist.SetMinimum(0.0)
+    hist.SetMaximum(4.5) 
+    yax.SetNdivisions(205)
+  elif 'Data' in ytitle:
+    hist.SetMinimum(0.0)
+    hist.SetMaximum(2.0) 
+    yax.SetNdivisions(205)
+   
+  gPad.SetTicky()
+  gPad.Update()
+
+
+#____________________________________________________________________________
+def myText(x, y, text, tsize=0.05, color=kBlack, angle=0) :
+  
+  l = TLatex()
+  l.SetTextSize(tsize)
+  l.SetTextFont(132)
+  l.SetNDC()
+  l.SetTextColor(color)
+  l.SetTextAngle(angle)
+  l.DrawLatex(x,y, text)
+
+
+#____________________________________________________________________________
+def mk_leg(xmin, ymin, xmax, ymax, sig_reg, l_samp, d_samp, nTotBkg, d_hists, d_yield, d_yieldErr, d_nRaw, sampSet_type='bkg', txt_size=0.05) :
+  '''
+  @l_samp : Constructs legend based on list of samples 
+  @nTotBkg : Total background events
+  @d_hists : The dictionary of histograms 
+  @d_samp : May from samples to legend text
+  @d_yields : The dictionary of yields 
+  @d_yieldErr : Dictionary of errors on the yields
+  @sampSet_type : The type of samples in the set of samples in the list 
+  '''  
+
+  # ---------------------------------------------------- 
+  # Legend: construct and format
+  # ---------------------------------------------------- 
+  leg = TLegend(xmin,ymin,xmax,ymax)
+  leg.SetBorderSize(0)
+  leg.SetTextSize(txt_size)
+  leg.SetTextFont(132)
+  leg.SetNColumns(1)
+
+  # legend markers 
+  d_legMk = {
+    'bkg'  : 'f',
+    'sig'  : 'l',
+    'data' : 'ep'
+    }
+
+  # Need to reverse background order so legend is filled as histogram is stacked
+  if sampSet_type == 'bkg':
+    l_samp = [x for x in reversed(l_samp)]
+  for samp in l_samp: 
+    #print( 'Processing {0}'.format(samp) )
+    # obtain sample attributes 
+    hist        = d_hists[samp][0]
+    sample_type = d_samp[samp]['type']
+    leg_entry   = d_samp[samp]['leg']
+    legMk       = d_legMk[sample_type]
+   
+    #print('samp: {0}, type: {1}, legMk: {2}'.format(samp, sample_type, legMk) ) 
+    # calculate the % of each background component and put in legend
+    pc_yield   = 0
+    if sample_type == 'bkg':
+      pc_yield = 100 * ( d_yield[samp] / float(nTotBkg) )
+      leg_txt = '{0} ({1:.3g}, {2:.1f}%, {3:.0f})'.format( leg_entry, d_yield[samp], pc_yield, d_nRaw[samp] )
+    if sample_type == 'sig':
+      #leg_txt = '{0} ({1:.3g}, {2:.0f})'.format(leg_entry, d_yield[samp], d_nRaw[samp])
+      leg_txt = leg_entry#, d_yield[samp], d_nRaw[samp])
+
+    if sample_type == 'data':
+      leg_txt = '{0} ({1:.0f} Events)'.format(leg_entry, d_yield['data'])  
+    leg.AddEntry(hist, leg_txt, legMk)
+    #print('{0}, {1}, {2:.3f}, {3:.3f}%'.format(sig_reg, samp, d_yield[samp], pc_yield) )
+    print('{0}, {1}, {2:.3f} +/- {3:.3f}, {4:.0f}'.format(sig_reg, samp, d_yield[samp], d_yieldErr[samp], d_nRaw[samp]) )
+  
+  return leg
+
+#____________________________________________________________________________
+def draw_line(xmin, ymin, xmax, ymax, color=kGray+1, style=2) :
+  
+  # draw line of kinematically forbidden region
+  line = TLine(xmin , ymin , xmax, ymax)
+  line.SetLineWidth(2)
+  line.SetLineStyle(style)
+  line.SetLineColor(color) # 12 = gray
+  return line
+ 
+#_________________________________________________________________________
+def mkdir(dirPath):
+  '''
+  make directory for given input path
+  '''
+  try:
+    os.makedirs(dirPath)
+    print 'Successfully made new directory ' + dirPath
+  except OSError:
+    pass
+ 
+if __name__ == "__main__":
+  #main(sys.argv)
+  main()
+
+

--- a/analysis/plotting/samples.py
+++ b/analysis/plotting/samples.py
@@ -89,8 +89,7 @@ def get_samples_to_plot(analysis = ''):
                  'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_5.0', 
                  #'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_10.0', 
                  #'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m5.0', 
-                 #'loose_noGenFilt_signal_hh_TopYuk_1.2_SlfCoup_1.0', 
-                 #'loose_noGenFilt_signal_hh_TopYuk_0.8_SlfCoup_1.0', 
+                 #'loose_noGenFilt_signal_hh_TopYuk_1.1_SlfCoup_1.0', 
     ]
 
 
@@ -303,89 +302,23 @@ def configure_samples():
     'loose_ptj1_1000_to_infty_4b'       :{'type':'bkg', 'leg':'4b 1000-#infty',   'f_color':myMediumBlue},
 
     'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_0.5':{'type':'sig','leg':'HH kl = 0','l_color':kBlue },
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_1.0':{'type':'sig','leg':'hh #kappa(#lambda_{hhh}) = 1','l_color': kRed+2 },
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_2.0':{'type':'sig','leg':'hh #kappa(#lambda_{hhh}) = 2','l_color': kAzure+1},
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_3.0':{'type':'sig','leg':'HH kl = 3','l_color':myLightBlue },
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_5.0':{'type':'sig','leg':'hh #kappa(#lambda_{hhh}) = 5','l_color': kBlue+2 },
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_7.0':{'type':'sig','leg':'HH kl = 7','l_color':myLightPink },
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_10.0':{'type':'sig','leg':'HH kl = 10','l_color':kBlue},
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m1.0':{'type':'sig','leg':'HH kl = -1','l_color':myMediumBlue },
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m2.0':{'type':'sig','leg':'HH kl = -2','l_color':myMediumGreen },
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m3.0':{'type':'sig','leg':'HH kl = -3','l_color':myMediumOrange },
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m5.0':{'type':'sig','leg':'HH kl = -5','l_color':kGreen },
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m7.0':{'type':'sig','leg':'HH kl = -7','l_color':myMediumPurple },
-    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m10.0':{'type':'sig','leg':'HH kl = -10','l_color':myDarkBlue },
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_1.0':{'type':'sig','leg':'#kappa_{#lambda} = 1','l_color': kRed+2 },
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_2.0':{'type':'sig','leg':'#kappa_{#lambda} = 2','l_color': kAzure+1},
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_3.0':{'type':'sig','leg':'#kappa_{#lambda} = 3','l_color':myLightBlue },
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_5.0':{'type':'sig','leg':'#kappa_{#lambda} = 5','l_color': kBlue+2 },
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_7.0':{'type':'sig','leg':'#kappa_{#lambda} = 7','l_color':myLightPink },
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_10.0':{'type':'sig','leg':'#kappa_{#lambda} = 10','l_color':myLightPink },
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m1.0':{'type':'sig','leg':'#kappa_{#lambda} = #minus1','l_color':myMediumBlue },
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m2.0':{'type':'sig','leg':'#kappa_{#lambda} = #minus2','l_color':myMediumGreen },
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m3.0':{'type':'sig','leg':'#kappa_{#lambda} = #minus3','l_color':myMediumOrange },
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m5.0':{'type':'sig','leg':'#kappa_{#lambda} = #minus5','l_color':kGreen },
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m7.0':{'type':'sig','leg':'#kappa_{#lambda} = #minus7','l_color':myMediumPurple },
+    'loose_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m10.0':{'type':'sig','leg':'#kappa_{#lambda} = #minus10','l_color':myDarkBlue },
 
     'loose_noGenFilt_signal_hh_TopYuk_0.8_SlfCoup_1.0':{'type':'sig','leg':'HH kt = 0.8','l_color':kBlue },
     'loose_noGenFilt_signal_hh_TopYuk_1.1_SlfCoup_1.0':{'type':'sig','leg':'HH kt = 1.1','l_color':kRed }, 
     'loose_noGenFilt_signal_hh_TopYuk_1.2_SlfCoup_1.0':{'type':'sig','leg':'HH kt = 1.2','l_color':myLightGreen }, 
      
-    #------------------------------------
-    # Resolved ATLAS analysis
-    #------------------------------------
-    
-    'resolved_noGenFilt_signal_hh_loop_sm_trackJetBTag':{'type':'sig','leg':'HH','l_color':kRed+3 },
-
-    'resolved_noGenFilt_bkg_ttbar_trackJetBTag':{'type':'bkg', 'leg':'ttbar', 'f_color':myLightPink},    
-    'resolved_ptj1_20_to_200_bkg_2b2j':{'type':'bkg', 'leg':'2b2j 20-200', 'f_color':myLightBlue},
-    'resolved_ptj1_200_to_500_bkg_2b2j':{'type':'bkg', 'leg':'2b2j 200-500', 'f_color':myLightGreen},
-    'resolved_ptj1_500_to_1000_bkg_2b2j':{'type':'bkg', 'leg':'2b2j 500-1000', 'f_color':myLightOrange},
-    'resolved_ptj1_1000_to_infty_bkg_2b2j':{'type':'bkg', 'leg':'2b2j 1000-infty', 'f_color':myLightPurple},
-    'resolved_ptj1_20_to_200_bkg_4b':{'type':'bkg', 'leg':'4b 20-200', 'f_color':myMediumBlue},
-    'resolved_ptj1_200_to_500_bkg_4b':{'type':'bkg', 'leg':'4b 200-500', 'f_color':myMediumGreen},
-    'resolved_ptj1_500_to_1000_bkg_4b':{'type':'bkg', 'leg':'4b 500-1000', 'f_color':myMediumOrange},
-    'resolved_ptj1_1000_to_infty_bkg_4b':{'type':'bkg', 'leg':'4b 1000-infty', 'f_color':myMediumPurple},
-
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_0.5':{'type':'sig','leg':'HH kl = 0','l_color':kBlue },
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_1.0':{'type':'sig','leg':'HH kl = 1','l_color':kRed },
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_2.0':{'type':'sig','leg':'HH kl = 2','l_color':myLighterOrange},
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_3.0':{'type':'sig','leg':'HH kl = 3','l_color':myLightBlue },
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_5.0':{'type':'sig','leg':'HH kl = 5','l_color':myLightGreen },
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_7.0':{'type':'sig','leg':'HH kl = 7','l_color':myLightPink },
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_10.0':{'type':'sig','leg':'HH kl = 10','l_color':kBlue},
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m1.0':{'type':'sig','leg':'HH kl = -1','l_color':myMediumBlue },
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m2.0':{'type':'sig','leg':'HH kl = -2','l_color':myMediumGreen },
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m3.0':{'type':'sig','leg':'HH kl = -3','l_color':myMediumOrange },
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m5.0':{'type':'sig','leg':'HH kl = -5','l_color':kGreen },
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m7.0':{'type':'sig','leg':'HH kl = -7','l_color':myMediumPurple },
-    'resolved_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m10.0':{'type':'sig','leg':'HH kl = -10','l_color':myDarkBlue },
-
-    'resolved_noGenFilt_signal_hh_TopYuk_0.8_SlfCoup_1.0':{'type':'sig','leg':'HH kt = 0.8','l_color':kBlue },
-    'resolved_noGenFilt_signal_hh_TopYuk_1.2_SlfCoup_1.0':{'type':'sig','leg':'HH kt = 1.2','l_color':myLightGreen }, 
-
-    #------------------------------------
-    # Boosted ATLAS analysis
-    #------------------------------------
-    
-    'boosted_noGenFilt_signal_hh_loop_sm_trackJetBTag':{'type':'sig','leg':'HH','l_color':kRed+3 },
-
-    'boosted_noGenFilt_bkg_ttbar_trackJetBTag':{'type':'bkg', 'leg':'ttbar', 'f_color':myLightPink},    
-    'boosted_ptj1_20_to_200_bkg_2b2j':{'type':'bkg', 'leg':'2b2j 20-200', 'f_color':myLightBlue},
-    'boosted_ptj1_200_to_500_bkg_2b2j':{'type':'bkg', 'leg':'2b2j 200-500', 'f_color':myLightGreen},
-    'boosted_ptj1_500_to_1000_bkg_2b2j':{'type':'bkg', 'leg':'2b2j 500-1000', 'f_color':myLightOrange},
-    'boosted_ptj1_1000_to_infty_bkg_2b2j':{'type':'bkg', 'leg':'2b2j 1000-infty', 'f_color':myLightPurple},
-    'boosted_ptj1_20_to_200_bkg_4b':{'type':'bkg', 'leg':'4b 20-200', 'f_color':myMediumBlue},
-    'boosted_ptj1_200_to_500_bkg_4b':{'type':'bkg', 'leg':'4b 200-500', 'f_color':myMediumGreen},
-    'boosted_ptj1_500_to_1000_bkg_4b':{'type':'bkg', 'leg':'4b 500-1000', 'f_color':myMediumOrange},
-    'boosted_ptj1_1000_to_infty_bkg_4b':{'type':'bkg', 'leg':'4b 1000-infty', 'f_color':myMediumPurple},
-
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_0.5':{'type':'sig','leg':'HH kl = 0','l_color':kBlue },
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_1.0':{'type':'sig','leg':'HH kl = kt = 1','l_color':kRed },
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_2.0':{'type':'sig','leg':'HH kl = 2','l_color':myLighterOrange},
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_3.0':{'type':'sig','leg':'HH kl = 3','l_color':myLightBlue },
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_5.0':{'type':'sig','leg':'HH kl = 5','l_color':myLightGreen },
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_7.0':{'type':'sig','leg':'HH kl = 7','l_color':myLightPink },
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_10.0':{'type':'sig','leg':'HH kl = 10','l_color':kBlue},
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m1.0':{'type':'sig','leg':'HH kl = -1','l_color':myMediumBlue },
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m2.0':{'type':'sig','leg':'HH kl = -2','l_color':myMediumGreen },
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m3.0':{'type':'sig','leg':'HH kl = -3','l_color':myMediumOrange },
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m5.0':{'type':'sig','leg':'HH kl = -5','l_color':kGreen },
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m7.0':{'type':'sig','leg':'HH kl = -7','l_color':myMediumPurple },
-    'boosted_noGenFilt_signal_hh_TopYuk_1.0_SlfCoup_m10.0':{'type':'sig','leg':'HH kl = -10','l_color':myDarkBlue },
-
-    'boosted_noGenFilt_signal_hh_TopYuk_0.8_SlfCoup_1.0':{'type':'sig','leg':'HH kt = 0.8','l_color':kBlue },
-    'boosted_noGenFilt_signal_hh_TopYuk_1.2_SlfCoup_1.0':{'type':'sig','leg':'HH kt = 1.2','l_color':myLightGreen }, 
-    
     }
   return d_samp
 

--- a/analysis/plotting/summary_1dlimits.py
+++ b/analysis/plotting/summary_1dlimits.py
@@ -70,63 +70,87 @@ plt.plot([-25.,-25], [-5,-5],'|',ms=0,mew=0,mec=intColor,ls='-',lw=intWidth,colo
 plt.plot([-25,-25.], [-5,-5],'|',ms=0,mew=0,mec=resColor,ls='-',lw=resWidth,color=resColor,label='$\mathrm{Resolved}$')
 plt.plot([-25.,-25.],[-5,-5],'|',ms=0,mew=0,mec=comColor,ls='-',lw=comWidth,color=comColor,label='$\mathrm{Combined}$')
 
-# Baseline, k(ytop) = 0.8, 1% syst
+% 5% systematic
 plt.plot([-25.,25.],  [18.,18.],  '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
-plt.plot([-19,25.],   [17.8,17.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
-plt.plot([-13.5,17.5],[17.6,17.6],'|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved
-plt.plot([-12.,15.5], [17.4,17.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined
-ax.text(-38,17.8,r'$\mathrm{Baseline}~1\%~\mathrm{systematics}$', size='20')
-ax.text(-38,17.1,r'$\kappa(y_\mathrm{top}) = 0.8$', size='14')
+plt.plot([-8.2,15.8], [17.8,17.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-5.5,11.9],[17.6,17.6],'|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved
+plt.plot([-4.7,11.6], [17.4,17.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined
+ax.text(-38,17.8,r'5\% syst', size='20')
 
-# Baseline, k(ytop) = 1, 1% syst
-plt.plot([-25.,25.],  [16.,16.],  '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
-plt.plot([-12.,18.5], [15.8,15.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor)  # Intermediate
-plt.plot([-10.5,16.], [15.6,15.6],'|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
-plt.plot([-8.,15.],   [15.4,15.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
-ax.text(-38,15.8,r'$\mathrm{Baseline}~1\%~\mathrm{systematics}$', size='20')
-ax.text(-38,15.1,r'$\kappa(y_\mathrm{top}) = 1$', size='14')
+# 2% syst
+plt.plot([-12.4,25.],  [16.,16.],   '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
+plt.plot([-4.2,14.4], [15.8,15.8], '|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-2.6,9.7], [15.6,15.6], '|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
+plt.plot([-2.5,9.4],   [15.4,15.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
+ax.text(-38,15.8,r'2\% syst', size='20')
 
-# DNN, k(ytop) = 0.8, 1% syst, trained on k(lambda) = 1
-plt.plot([-11.5,25.],[14.,14.],  '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
-plt.plot([-8,12.],   [13.8,13.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor)  # Intermediate
-plt.plot([-7,10.5],  [13.6,13.6],'|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
-plt.plot([-6,10.5],  [13.4,13.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
-ax.text(-38,13.8,r'$\mathrm{DNN}~1\%~\mathrm{systematics}$', size='20')
-ax.text(-38,13.1,r'$\kappa(y_\mathrm{top}) = 0.8,~\mathrm{trained~on}~\kappa(\lambda_{hhh}) = 1$', size='14')
+# 1.5% syst
+plt.plot([-11.0,25.],[14.,14.],   '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
+plt.plot([-3.8,12.6],[13.8,13.8], '|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-2.4,8.9], [13.6,13.6], '|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
+plt.plot([-2.2,8.8],  [13.4,13.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
+ax.text(-38,15.8,r'1.5\% syst', size='20')
 
-# DNN, k(ytop) = 1, 1% syst, trained on k(lambda) = 1
-plt.plot([-11.5,25.],[12.,12.],  '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
-plt.plot([-4.5,11.], [11.8,11.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor)  # Intermediate
-plt.plot([-4,10.5],  [11.6,11.6],'|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
-plt.plot([-3.5,10.],  [11.4,11.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
-ax.text(-38,11.8,r'$\mathrm{DNN}~1\%~\mathrm{systematics}$', size='20')
-ax.text(-38,11.1,r'$\kappa(y_\mathrm{top}) = 1,~\mathrm{trained~on}~\kappa(\lambda_{hhh}) = 1$', size='14')
+# 1% syst
+plt.plot([-10.1,17.6],[12.,12.],  '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
+plt.plot([-3.4,11.4], [11.8,11.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-2.0,8.2],  [11.6,11.6], '|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
+plt.plot([-1.9,8.1],  [11.4,11.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
+ax.text(-38,15.8,r'1\% syst', size='20')
 
-# DNN, k(ytop) = 1, 1% syst, trained on k(lambda) = 10
-plt.plot([-16,25.], [10.,10.],'|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
-plt.plot([-4,11.],  [9.8,9.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor)  # Intermediate
-plt.plot([-5,10.],  [9.6,9.6],'|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
-plt.plot([-3.5,10.],[9.4,9.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
-ax.text(-38,9.8,r'$\mathrm{DNN}~1\%~\mathrm{systematics}$', size='20')
-ax.text(-38,9.1,r'$\kappa(y_\mathrm{top}) = 1,~\mathrm{trained~on}~\kappa(\lambda_{hhh}) = 10$', size='14')
+# 0.3% syst
+plt.plot([-8.2,13.9],[12.,12.],   '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
+plt.plot([-3.1,10.5],[11.8,11.8], '|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-0.97,6.7],[11.6,11.6], '|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
+plt.plot([-0.8,6.6],  [11.4,11.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
+ax.text(-38,15.8,r'0.3% syst', size='20')
 
-# DNN, k(ytop) = 1, 0.5% syst, trained on k(lambda) = 1
-plt.plot([-10.3,25.],[8.,8.],  '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
-plt.plot([-3.8,10.6],[7.8,7.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor)  # Intermediate
-plt.plot([-2.6,9.4], [7.6,7.6],'|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
-plt.plot([-2.4,9.1], [7.4,7.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
-ax.text(-38,7.8,r'$\mathrm{DNN}~0.5\%~\mathrm{systematics}$', size='20')
-ax.text(-38,7.1,r'$\kappa(y_\mathrm{top}) = 1,~\mathrm{trained~on}~\kappa(\lambda_{hhh}) = 1$', size='14')
+# 0% syst
+plt.plot([-8.0,13.2], [12.,12.],  '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
+plt.plot([-3.0,10.4], [11.8,11.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-0.8,6.4],  [11.6,11.6],'|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
+plt.plot([-0.7,6.3],  [11.4,11.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
+ax.text(-38,15.8,r'0\% syst', size='20')% 5% systematic
+plt.plot([-25.,25.],  [18.,18.],  '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
+plt.plot([-8.2,15.8], [17.8,17.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-5.5,11.9],[17.6,17.6],'|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved
+plt.plot([-4.7,11.6], [17.4,17.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined
+ax.text(-38,17.8,r'5\% syst', size='20')
 
-# DNN, k(ytop) = 1, 0.5% syst, trained on k(lambda) = 10
-plt.plot([-15.8,25.],[6.,6.],  '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
-plt.plot([-3.8,10.8],[5.8,5.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor)  # Intermediate
-plt.plot([-3.4,8.8], [5.6,5.6],'|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
-plt.plot([-2.9,8.4], [5.4,5.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
-ax.text(-38,5.8,r'$\mathrm{DNN}~0.5\%~\mathrm{systematics}$', size='20')
-ax.text(-38,5.1,r'$\kappa(y_\mathrm{top}) = 1,~\mathrm{trained~on}~\kappa(\lambda_{hhh}) = 10$', size='14')
+# 2% syst
+plt.plot([-12.4,25.],  [16.,16.],   '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
+plt.plot([-4.2,14.4], [15.8,15.8], '|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-2.6,9.7], [15.6,15.6], '|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
+plt.plot([-2.5,9.4],   [15.4,15.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
+ax.text(-38,15.8,r'2\% syst', size='20')
 
+# 1.5% syst
+plt.plot([-11.0,25.],[14.,14.],   '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
+plt.plot([-3.8,12.6],[13.8,13.8], '|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-2.4,8.9], [13.6,13.6], '|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
+plt.plot([-2.2,8.8],  [13.4,13.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
+ax.text(-38,15.8,r'1.5\% syst', size='20')
 
+# 1% syst
+plt.plot([-10.1,17.6],[12.,12.],  '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
+plt.plot([-3.4,11.4], [11.8,11.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-2.0,8.2],  [11.6,11.6], '|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
+plt.plot([-1.9,8.1],  [11.4,11.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
+ax.text(-38,15.8,r'1\% syst', size='20')
+
+# 0.3% syst
+plt.plot([-8.2,13.9],[12.,12.],   '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
+plt.plot([-3.1,10.5],[11.8,11.8], '|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-0.97,6.7],[11.6,11.6], '|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
+plt.plot([-0.8,6.6],  [11.4,11.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
+ax.text(-38,15.8,r'0.3% syst', size='20')
+
+# 0% syst
+plt.plot([-8.0,13.2], [12.,12.],  '|',ms=10,mew=3,mec=bstColor,ls='-',lw=bstWidth,color=bstColor) # Boosted
+plt.plot([-3.0,10.4], [11.8,11.8],'|',ms=10,mew=3,mec=intColor,ls='-',lw=intWidth,color=intColor) # Intermediate
+plt.plot([-0.8,6.4],  [11.6,11.6],'|',ms=10,mew=3,mec=resColor,ls='-',lw=resWidth,color=resColor) # Resolved 
+plt.plot([-0.7,6.3],  [11.4,11.4],'|',ms=10,mew=3,mec=comColor,ls='-',lw=comWidth,color=comColor) # Combined  
+ax.text(-38,15.8,r'0\% syst', size='20')
 # Label the range of SMEFT line
 #ax.text(-0.055, 0.25,r'$\Lambda = 140~\mathrm{GeV}$', size='20')
 ax.text(2.5,1.3,r'$\sqrt{s} = 14~\mathrm{TeV},~3000~\mathrm{fb}^{-1}$', size='20')


### PR DESCRIPTION
Updating plotting scripts for final results for 17 Feb draft
- Cleaned up samples.py
- Added plot_signal_only.py for unit normalised reco signal only plots
- contours_to_summary.py has clearer colour scheme and thinner combined line
- chiSq_to_contour.py adopts a dedicated improved colour palette for temperature scale
- chiSq_to_1Dlimit.py now labels systematics in legend for mixed chi sq plots
- summary_1dlimits.py now summarises 68% CL limits for different systematics